### PR TITLE
Ipopt install path + smoke test for LivePulsePlotCallback (0.2a)

### DIFF
--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -580,6 +580,40 @@ end
     @test stat(joinpath(save_dir, pngs[1])).size != stat(joinpath(save_dir, pngs[2])).size
 end
 
+@testitem "LivePulsePlotCallback attaches to an Ipopt solve (per-iter PNGs end-to-end)" begin
+    using DirectTrajOpt
+    using NamedTrajectories
+    using CairoMakie
+    using Random
+
+    # 0.2a install-path smoke test: the SAME callback object Piccolo hands to
+    # MadNLP installs on an Ipopt solve via IpoptOptions(intermediate_callback=cb)
+    # and emits iter_<N>.png through the AbstractIntermediateCallback abstraction.
+    Random.seed!(11)
+    sys = QuantumSystem(0.5 * PAULIS[:Z], [PAULIS[:X], PAULIS[:Y]], [1.0, 1.0])
+    T, N = 5.0, 20
+    times = collect(range(0, T, length = N))
+    qtraj = UnitaryTrajectory(sys, ZeroOrderPulse(0.1 * randn(2, N), times), GATES[:X])
+    qcp = SmoothPulseProblem(
+        qtraj,
+        N;
+        piccolo_options = PiccoloOptions(timesteps_all_equal = true, verbose = false),
+    )
+
+    save_dir = mktempdir()
+    cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = save_dir)
+    @test cb isa DirectTrajOpt.AbstractIntermediateCallback
+
+    solve!(
+        qcp;
+        options = IpoptOptions(max_iter = 5, intermediate_callback = cb, print_level = 0),
+        verbose = false,
+    )
+
+    pngs = filter(f -> endswith(f, ".png"), readdir(save_dir))
+    @test length(pngs) > 0   # per-iter frames flowed through the callback during the solve
+end
+
 @testitem "LivePulsePlotCallback every > 1 skips renders" begin
     using DirectTrajOpt
     using NamedTrajectories

--- a/src/visualizations/live_callbacks.jl
+++ b/src/visualizations/live_callbacks.jl
@@ -17,11 +17,17 @@ renders it with `plot_pulse(pulse; title = "\$title_prefix \$iter")`, and
 (if `save_dir` is set) writes a PNG snapshot to disk.
 
 The returned callback subtypes `DirectTrajOpt.AbstractIntermediateCallback`,
-so it can be passed directly to any DTO solver backend:
+so the SAME callback object installs unchanged on any DTO solver backend via that
+backend's `intermediate_callback` option:
 
 ```julia
 cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = "out/")
+
+# MadNLP backend
 solve!(qcp; options = MadNLPOptions(intermediate_callback = cb))
+
+# Ipopt backend — same install path, same per-iter PNGs
+solve!(qcp; options = IpoptOptions(intermediate_callback = cb))
 ```
 
 # Arguments
@@ -33,11 +39,13 @@ solve!(qcp; options = MadNLPOptions(intermediate_callback = cb))
 - `save_dir`: if non-`nothing`, save `iter_NNN.png` per rendered iter.
 - `title_prefix`: title-bar prefix, joined to the iter count.
 
-# MadNLP note
+# Backend note
 The callback needs the full primal vector (including fixed boundary variables) to
-reconstruct the trajectory faithfully. DTO sets `fixed_variable_treatment =
-MadNLP.RelaxBound` automatically when it sees an `AbstractIntermediateCallback`
-installed without an explicit value — you don't need to set it yourself.
+reconstruct the trajectory faithfully. Under MadNLP, DTO sets
+`fixed_variable_treatment = MadNLP.RelaxBound` automatically when it sees an
+`AbstractIntermediateCallback` installed without an explicit value — you don't
+need to set it yourself. Under Ipopt the full primal is always available, so no
+analogous treatment is required.
 
 Defined as a stub here; the implementation is provided by the `PiccoloMakieExt`
 extension and is loaded when a Makie backend (`CairoMakie`, `GLMakie`, `WGLMakie`)


### PR DESCRIPTION
Companion to **DirectTrajOpt.jl#114** for **harmoniqs/amicode#19** (Phase 0′, task 0.2a).

`LivePulsePlotCallback` already subtypes `DirectTrajOpt.AbstractIntermediateCallback`, so once DTO's Ipopt backend accepts an `intermediate_callback` (DTO#114), the **same** callback object installs on an Ipopt solve exactly as it does on MadNLP. This PR documents + tests that path.

## Change
- **`src/visualizations/live_callbacks.jl`** — docstring now shows the `IpoptOptions(intermediate_callback = cb)` install path alongside the existing MadNLP one, and notes Ipopt needs no `RelaxBound`-style treatment (full primal always available).
- **`ext/PiccoloMakieExt.jl`** — new end-to-end `@testitem` that attaches `LivePulsePlotCallback` to an Ipopt `SmoothPulseProblem` solve and asserts per-iter `iter_<N>.png` frames are emitted through the callback.

No mechanism code changes — `LivePulsePlotCallback` already reconstructs the trajectory from the primal each iter; this PR proves the Ipopt install path works and pins it with a test.

## Validation (gpu-dev-v2)
Ran the new smoke test against this branch with DTO#114 dev-coupled: **Piccolo tests passed** — the Ipopt solve emits per-iter PNGs through `LivePulsePlotCallback` end-to-end.

## Dependency
Needs DirectTrajOpt with the Ipopt `intermediate_callback` field (DTO#114). The pin `DirectTrajOpt = "0.9.5"` already admits the forthcoming patch release (v0.9.7); CI here goes green once that release is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)