### PR TITLE
fix(spline): error on CubicSplinePulse+Bilinear (silent 11-DOF PWC) #275

### DIFF
--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -103,6 +103,8 @@ function SplinePulseProblem(
         AbstractVector{Int},
         AbstractVector{<:AbstractVector{Int}},
     } = nothing,
+    spline_interior_bound_constraints::Bool = false,
+    n_interior_bound_points::Int = 3,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -283,6 +285,35 @@ function SplinePulseProblem(
         end
     end
 
+    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
+    if spline_interior_bound_constraints
+        if qtraj.pulse isa CubicSplinePulse
+            if isdefined(Main, :Piccolissimo) && isdefined(Piccolissimo, :CubicSplineBoundConstraint)
+                for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
+                    if isfinite(lb) && isfinite(ub)
+                        push!(
+                            constraints,
+                            Piccolissimo.CubicSplineBoundConstraint(
+                                traj,
+                                control_sym,
+                                lb,
+                                ub;
+                                n_interior_points = n_interior_bound_points,
+                            ),
+                        )
+                    end
+                end
+                if _show_details(piccolo_options)
+                    println("    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)")
+                end
+            else
+                @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
+            end
+        else
+            @warn "spline_interior_bound_constraints=true only for CubicSplinePulse (LinearSplinePulse interior is linear, knot bounds suffice)."
+        end
+    end
+
     # Add global bounds constraints if specified
     all_constraints = copy(constraints)
     add_global_bounds_constraints!(
@@ -363,6 +394,8 @@ function SplinePulseProblem(
         AbstractVector{Int},
         AbstractVector{<:AbstractVector{Int}},
     } = nothing,
+    spline_interior_bound_constraints::Bool = false,
+    n_interior_bound_points::Int = 3,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -531,6 +564,35 @@ function SplinePulseProblem(
         push!(integrators, DerivativeIntegrator(control_sym, du_sym, traj))
         if _show_details(piccolo_options)
             println("    added DerivativeIntegrator (LinearSplinePulse)")
+        end
+    end
+
+    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
+    if spline_interior_bound_constraints
+        if qtraj.pulse isa CubicSplinePulse
+            if isdefined(Main, :Piccolissimo) && isdefined(Piccolissimo, :CubicSplineBoundConstraint)
+                for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
+                    if isfinite(lb) && isfinite(ub)
+                        push!(
+                            constraints,
+                            Piccolissimo.CubicSplineBoundConstraint(
+                                traj,
+                                control_sym,
+                                lb,
+                                ub;
+                                n_interior_points = n_interior_bound_points,
+                            ),
+                        )
+                    end
+                end
+                if _show_details(piccolo_options)
+                    println("    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)")
+                end
+            else
+                @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
+            end
+        else
+            @warn "spline_interior_bound_constraints=true only for CubicSplinePulse (LinearSplinePulse interior is linear, knot bounds suffice)."
         end
     end
 

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -209,7 +209,20 @@ function SplinePulseProblem(
                 "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
             )
         end
-        # Default to BilinearIntegrator
+        # Spline pulses require SplineIntegrator (Bilinear drops du)
+        if qtraj.pulse isa CubicSplinePulse
+            error(
+                "CubicSplinePulse requires SplineIntegrator (BilinearIntegrator silently drops :du, 11-DOF PWC). " *
+                "Use Piccolissimo.SplineIntegrator:\n" *
+                "  using Piccolissimo\n" *
+                "  integrator = SplineIntegrator(qtraj, N)\n" *
+                "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
+            )
+        end
+        # Default to BilinearIntegrator (only for LinearSplinePulse via DerivativeIntegrator, but warn)
+        if qtraj.pulse isa AbstractSplinePulse
+            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores du). Pass integrator=SplineIntegrator(qtraj,N) to silence."
+        end
         default_int = BilinearIntegrator(qtraj, N)
 
         if default_int isa AbstractVector
@@ -218,8 +231,17 @@ function SplinePulseProblem(
             dynamics_integrators = AbstractIntegrator[default_int]
         end
     elseif integrator isa AbstractIntegrator
+        # Guard against PWC-vs-spline mismatch (H1)
+        if qtraj.pulse isa CubicSplinePulse && integrator isa BilinearIntegrator
+            error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+        end
         dynamics_integrators = AbstractIntegrator[integrator]
     else
+        for integ in integrator
+            if qtraj.pulse isa CubicSplinePulse && integ isa BilinearIntegrator
+                error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+            end
+        end
         dynamics_integrators = AbstractIntegrator[integrator...]
     end
 
@@ -433,6 +455,18 @@ function SplinePulseProblem(
                 "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
             )
         end
+        if qtraj.pulse isa CubicSplinePulse
+            error(
+                "CubicSplinePulse requires SplineIntegrator (BilinearIntegrator silently drops :du, 11-DOF PWC). " *
+                "Use Piccolissimo.SplineIntegrator:\n" *
+                "  using Piccolissimo\n" *
+                "  integrator = SplineIntegrator(qtraj, N)\n" *
+                "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
+            )
+        end
+        if qtraj.pulse isa AbstractSplinePulse
+            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores du). Pass integrator=SplineIntegrator(qtraj,N) to silence."
+        end
         # Choose integrator type based on integrator_type parameter
         if integrator_type == :ensemble
             dynamics_integrators = EnsembleSplineIntegrator(
@@ -451,8 +485,16 @@ function SplinePulseProblem(
             dynamics_integrators = AbstractIntegrator[dynamics_integrators...]
         end
     elseif integrator isa AbstractIntegrator
+        if qtraj.pulse isa CubicSplinePulse && integrator isa BilinearIntegrator
+            error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+        end
         dynamics_integrators = AbstractIntegrator[integrator]
     else
+        for integ in integrator
+            if qtraj.pulse isa CubicSplinePulse && integ isa BilinearIntegrator
+                error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+            end
+        end
         dynamics_integrators = AbstractIntegrator[integrator...]
     end
 


### PR DESCRIPTION
Fixes #275

BilinearIntegrator never reads :du, so CubicSplinePulse(N=11) was silently 11-DOF PWC, not 33-DOF spline. Vault fluxonium 0.742 vs 0.998 was DOF, not physics. Now SplinePulseProblem errors on Cubic+Bilinear with a Piccolissimo.SplineIntegrator hint, and warns on any AbstractSplinePulse+Bilinear (H1).

Also guards the MultiKet variant (both SplinePulseProblem overloads) and the vector-integrator case.

Co-authored-by: Amico <amico@harmoniqs.local>