### PR TITLE
fix(spline): land the #275/#276 guards on main — spline pulses can no longer silently land on PWC dynamics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
     tags: ['*']
+  workflow_dispatch:
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags: ["*"]
+  workflow_dispatch:
   repository_dispatch:
     types: [tagbot-release-created]
 concurrency:

--- a/docs/literate/concepts/trajectories.jl
+++ b/docs/literate/concepts/trajectories.jl
@@ -294,7 +294,7 @@ length(Δts)
 # # For SplinePulseProblem
 # pulse = CubicSplinePulse(controls, tangents, times)
 # qtraj = UnitaryTrajectory(sys, pulse, U_goal)
-# qcp = SplinePulseProblem(qtraj)  # ✓
+# qcp = SplinePulseProblem(qtraj; integrator_type = :pwc)  # ✓ (cubic requires the declaration)
 # ```
 #
 # ### 2. Initialize with Reasonable Controls

--- a/docs/literate/problem-templates/composition.jl
+++ b/docs/literate/problem-templates/composition.jl
@@ -140,7 +140,7 @@ get_duration(get_trajectory(qcp_mintime))
 # qtraj_spline = UnitaryTrajectory(sys, spline_pulse, U_goal)
 #
 # # Refine with spline problem
-# qcp_spline = SplinePulseProblem(qtraj_spline; Q=100.0)
+# qcp_spline = SplinePulseProblem(qtraj_spline; Q=100.0, integrator_type = :pwc)
 # solve!(qcp_spline; max_iter=50)  # Quick refinement
 # ```
 #

--- a/docs/literate/problem-templates/spline_pulse.jl
+++ b/docs/literate/problem-templates/spline_pulse.jl
@@ -213,6 +213,7 @@ qcp_per_drive = SplinePulseProblem(
     qtraj;
     Q = 100.0,
     du_bounds = [5.0, 2.0],  ## drive 1 allows faster slopes than drive 2
+    integrator_type = :pwc,  ## declared PWC — see the warning above
 )
 
 # ## Trajectory Structure

--- a/docs/literate/problem-templates/spline_pulse.jl
+++ b/docs/literate/problem-templates/spline_pulse.jl
@@ -27,12 +27,13 @@
 # # Linear spline
 # pulse = LinearSplinePulse(controls, times)
 # qtraj = UnitaryTrajectory(sys, pulse, U_goal)
-# qcp = SplinePulseProblem(qtraj)  # Works
+# qcp = SplinePulseProblem(qtraj)  # Works (warns: default PWC integrator)
 #
-# # Cubic spline
+# # Cubic spline — the integrator choice must be explicit (#275)
 # pulse = CubicSplinePulse(controls, tangents, times)
 # qtraj = UnitaryTrajectory(sys, pulse, U_goal)
-# qcp = SplinePulseProblem(qtraj)  # Works
+# qcp = SplinePulseProblem(qtraj; integrator_type = :pwc)  # acknowledged PWC
+# # or, for spline-faithful dynamics: integrator = Piccolissimo.SplineIntegrator(qtraj, N)
 # ```
 #
 # ## Constructor Variants
@@ -113,16 +114,20 @@ pulse = CubicSplinePulse(controls, tangents, times)
 qtraj = UnitaryTrajectory(sys, pulse, GATES[:X])
 
 ## Solve using native knot times
-qcp = SplinePulseProblem(qtraj; Q = 100.0, du_bound = 10.0)
+## `integrator_type = :pwc` acknowledges (see the warning below) that Piccolo's
+## only built-in integrator treats the drive as piecewise constant.
+qcp = SplinePulseProblem(qtraj; Q = 100.0, du_bound = 10.0, integrator_type = :pwc)
 cached_solve!(qcp, "spline_pulse_basic"; max_iter = 100)
 
 # !!! warning "The default integrator is piecewise constant — check the divergence"
-#     Every `SplinePulseProblem` on this page uses the **default** integrator, which is
+#     Every solve on this page uses the **PWC** integrator (`integrator_type = :pwc`),
 #     `BilinearIntegrator`: it models the drive as **piecewise constant on each interval**. That
 #     is not what a spline pulse is, so the optimizer is minimizing against a different waveform
 #     than the one your pulse actually produces. For a `CubicSplinePulse` it is worse still — the
 #     Hermite tangents (`:du`) get no gradient at all, so they simply sit at their initial values
-#     and are then integrated for real by the re-rollout.
+#     and are then integrated for real by the re-rollout. Constructing a cubic-spline problem
+#     without declaring the integrator choice is an **error** as of #275 — this page declares
+#     `:pwc` explicitly so you can see exactly what you are getting.
 #
 #     This is easy to *see* rather than take on faith. `rollout_divergence` compares the
 #     optimizer's collocation solution against an ODE re-rollout of the same pulse at the final
@@ -172,7 +177,7 @@ verify(qcp)
 # qtraj = UnitaryTrajectory(sys, saved_pulse, U_goal)
 #
 # # Use native knot times (no resampling)
-# qcp = SplinePulseProblem(qtraj)
+# qcp = SplinePulseProblem(qtraj; integrator_type = :pwc)
 # solve!(qcp; max_iter=50)  # Converges quickly from good initial guess
 # ```
 #
@@ -180,7 +185,7 @@ verify(qcp)
 #
 # The original pulse above has 50 knots. We can resample to 100 for finer control:
 
-qcp_resampled = SplinePulseProblem(qtraj, 100; Q = 100.0)
+qcp_resampled = SplinePulseProblem(qtraj, 100; Q = 100.0, integrator_type = :pwc)
 cached_solve!(qcp_resampled, "spline_pulse_resampled"; max_iter = 100)
 
 # ### Linear vs Cubic Splines

--- a/docs/literate/problem-templates/spline_pulse.jl
+++ b/docs/literate/problem-templates/spline_pulse.jl
@@ -201,7 +201,7 @@ qcp_linear = SplinePulseProblem(qtraj_linear)
 
 pulse_cubic = CubicSplinePulse(controls, tangents, times)
 qtraj_cubic = UnitaryTrajectory(sys, pulse_cubic, GATES[:X])
-qcp_cubic = SplinePulseProblem(qtraj_cubic)
+qcp_cubic = SplinePulseProblem(qtraj_cubic; integrator_type = :pwc)  # declared PWC — see the warning above
 ## du (tangents) are independent variables
 
 # ### Per-Drive Derivative Bounds

--- a/docs/literate/two_qubit_gate_validation.jl
+++ b/docs/literate/two_qubit_gate_validation.jl
@@ -217,6 +217,7 @@ qcp_cub = SplinePulseProblem(
     Q = 100.0,
     R_du = 0.1,
     piccolo_options = PiccoloOptions(timesteps_all_equal = true),
+    integrator_type = :pwc,  # declared PWC — see the spline_pulse template's warning
 )
 
 cached_solve!(qcp_cub, "two_qubit_cubic_spline"; max_iter = 80)

--- a/src/control/problems.jl
+++ b/src/control/problems.jl
@@ -403,8 +403,8 @@ Solve the quantum control problem by forwarding to the inner DirectTrajOptProble
 All other keyword arguments are passed to the DirectTrajOpt solver.
 
 Returns `DirectTrajOpt.Solvers.SolveStats` (termination status, raw status string,
-NLP objective, IPM iterations, solve wall time, solver symbol) once DirectTrajOpt
-provides it; `nothing` until then.
+NLP objective, IPM iterations, solve wall time, solver symbol) —
+computed after the trajectory sync, describing the trajectory you hold.
 """
 function solve!(
     qcp::QuantumControlProblem;
@@ -416,8 +416,7 @@ function solve!(
 )
     # SolveStats (status, iterations, objective, wall time) from the backend —
     # returned AFTER the trajectory sync so callers get data describing the
-    # trajectory they actually hold. (Returns nothing until DirectTrajOpt's
-    # registry release carries the SolveStats return.)
+    # trajectory they actually hold.
     stats = solve!(qcp.prob; verbose = verbose, kwargs...)
     if sync
         sync_trajectory!(

--- a/src/control/templates/sampling_problem.jl
+++ b/src/control/templates/sampling_problem.jl
@@ -631,7 +631,7 @@ end
     # Cubic spline: :du is Hermite tangents (free DOFs) — no DerivativeIntegrator
     cubic_pulse = CubicSplinePulse(0.1 * randn(1, N), 0.1 * randn(1, N), times)
     cubic_qtraj = UnitaryTrajectory(sys, cubic_pulse, GATES[:H])
-    cubic_qcp = SplinePulseProblem(cubic_qtraj, N; Q = 100.0)
+    cubic_qcp = SplinePulseProblem(cubic_qtraj, N; Q = 100.0, integrator_type = :pwc)
 
     cubic_sampling = SamplingProblem(cubic_qcp, [sys, sys])
     cubic_traj = get_trajectory(cubic_sampling)

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -1248,12 +1248,14 @@ end
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
 
     # Attempting to use global_bounds without globals in trajectory should error
+    # (declare the PWC backend so the #275 guard doesn't fire first)
     @test_throws "Global variable :δ not found" SplinePulseProblem(
         qtraj,
         N;
         Q = 100.0,
         R = 1e-2,
         global_bounds = Dict(:δ => 0.5),  # δ doesn't exist in trajectory
+        integrator_type = :pwc,
     )
 end
 
@@ -1484,7 +1486,7 @@ end
     U_goal = ComplexF64[0 1; 1 0]
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
 
-    qcp = SplinePulseProblem(qtraj, N; Q = 100.0)  # no explicit R_u, R_du
+    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, integrator_type = :pwc)  # no explicit R_u, R_du
 
     @test qcp isa QuantumControlProblem
 

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -262,7 +262,20 @@ function SplinePulseProblem(
                 "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
             )
         end
-        # Default to BilinearIntegrator
+        # Spline pulses require SplineIntegrator (Bilinear drops du)
+        if qtraj.pulse isa CubicSplinePulse
+            error(
+                "CubicSplinePulse requires SplineIntegrator (BilinearIntegrator silently drops :du, 11-DOF PWC). " *
+                "Use Piccolissimo.SplineIntegrator:\n" *
+                "  using Piccolissimo\n" *
+                "  integrator = SplineIntegrator(qtraj, N)\n" *
+                "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
+            )
+        end
+        # Default to BilinearIntegrator (only for LinearSplinePulse via DerivativeIntegrator, but warn)
+        if qtraj.pulse isa AbstractSplinePulse
+            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores du). Pass integrator=SplineIntegrator(qtraj,N) to silence."
+        end
         default_int = BilinearIntegrator(qtraj, N)
 
         if default_int isa AbstractVector
@@ -271,8 +284,17 @@ function SplinePulseProblem(
             dynamics_integrators = AbstractIntegrator[default_int]
         end
     elseif integrator isa AbstractIntegrator
+        # Guard against PWC-vs-spline mismatch (H1)
+        if qtraj.pulse isa CubicSplinePulse && integrator isa BilinearIntegrator
+            error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+        end
         dynamics_integrators = AbstractIntegrator[integrator]
     else
+        for integ in integrator
+            if qtraj.pulse isa CubicSplinePulse && integ isa BilinearIntegrator
+                error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+            end
+        end
         dynamics_integrators = AbstractIntegrator[integrator...]
     end
 
@@ -518,6 +540,23 @@ function SplinePulseProblem(
                    parallel integrator via `integrator = ...` instead." maxlog = 1
         end
 
+        # Spline pulses must not silently land on the PWC default: BilinearIntegrator
+        # never reads :du, so a CubicSplinePulse would optimize a piecewise-constant
+        # waveform while the name promises a spline (issue #275).
+        if qtraj.pulse isa CubicSplinePulse
+            error(
+                "CubicSplinePulse requires SplineIntegrator (BilinearIntegrator silently drops :du — " *
+                "the problem would optimize a PWC waveform, not a spline). " *
+                "Use Piccolissimo.SplineIntegrator:\n" *
+                "  using Piccolissimo\n" *
+                "  integrator = SplineIntegrator(qtraj, N)\n" *
+                "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
+            )
+        end
+        if qtraj.pulse isa AbstractSplinePulse
+            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores :du)." maxlog = 1
+        end
+
         # `integrator_type` names what you actually get. `:pwc` is the only backend Piccolo
         # ships: `BilinearIntegrator`, which models the drive as piecewise constant on each
         # interval. There is deliberately no `:spline` value — see the errors below.
@@ -568,8 +607,16 @@ function SplinePulseProblem(
             dynamics_integrators = AbstractIntegrator[dynamics_integrators...]
         end
     elseif integrator isa AbstractIntegrator
+        if qtraj.pulse isa CubicSplinePulse && integrator isa BilinearIntegrator
+            error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+        end
         dynamics_integrators = AbstractIntegrator[integrator]
     else
+        for integ in integrator
+            if qtraj.pulse isa CubicSplinePulse && integ isa BilinearIntegrator
+                error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+            end
+        end
         dynamics_integrators = AbstractIntegrator[integrator...]
     end
 

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -150,6 +150,8 @@ function SplinePulseProblem(
         AbstractVector{Int},
         AbstractVector{<:AbstractVector{Int}},
     } = nothing,
+    spline_interior_bound_constraints::Bool = false,
+    n_interior_bound_points::Int = 3,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -344,6 +346,35 @@ function SplinePulseProblem(
         end
     end
 
+    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
+    if spline_interior_bound_constraints
+        if qtraj.pulse isa CubicSplinePulse
+            if isdefined(Main, :Piccolissimo) && isdefined(Piccolissimo, :CubicSplineBoundConstraint)
+                for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
+                    if isfinite(lb) && isfinite(ub)
+                        push!(
+                            constraints,
+                            Piccolissimo.CubicSplineBoundConstraint(
+                                traj,
+                                control_sym,
+                                lb,
+                                ub;
+                                n_interior_points = n_interior_bound_points,
+                            ),
+                        )
+                    end
+                end
+                if _show_details(piccolo_options)
+                    println("    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)")
+                end
+            else
+                @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
+            end
+        else
+            @warn "spline_interior_bound_constraints=true only for CubicSplinePulse (LinearSplinePulse interior is linear, knot bounds suffice)."
+        end
+    end
+
     # Add global bounds constraints if specified
     all_constraints = copy(constraints)
     add_global_bounds_constraints!(
@@ -436,6 +467,8 @@ function SplinePulseProblem(
         AbstractVector{Int},
         AbstractVector{<:AbstractVector{Int}},
     } = nothing,
+    spline_interior_bound_constraints::Bool = false,
+    n_interior_bound_points::Int = 3,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -667,6 +700,35 @@ function SplinePulseProblem(
         push!(integrators, DerivativeIntegrator(control_sym, du_sym, traj))
         if _show_details(piccolo_options)
             println("    added DerivativeIntegrator (LinearSplinePulse)")
+        end
+    end
+
+    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
+    if spline_interior_bound_constraints
+        if qtraj.pulse isa CubicSplinePulse
+            if isdefined(Main, :Piccolissimo) && isdefined(Piccolissimo, :CubicSplineBoundConstraint)
+                for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
+                    if isfinite(lb) && isfinite(ub)
+                        push!(
+                            constraints,
+                            Piccolissimo.CubicSplineBoundConstraint(
+                                traj,
+                                control_sym,
+                                lb,
+                                ub;
+                                n_interior_points = n_interior_bound_points,
+                            ),
+                        )
+                    end
+                end
+                if _show_details(piccolo_options)
+                    println("    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)")
+                end
+            else
+                @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
+            end
+        else
+            @warn "spline_interior_bound_constraints=true only for CubicSplinePulse (LinearSplinePulse interior is linear, knot bounds suffice)."
         end
     end
 

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -288,13 +288,17 @@ function SplinePulseProblem(
     elseif integrator isa AbstractIntegrator
         # Guard against PWC-vs-spline mismatch (H1)
         if qtraj.pulse isa CubicSplinePulse && integrator isa BilinearIntegrator
-            error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+            error(
+                "CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.",
+            )
         end
         dynamics_integrators = AbstractIntegrator[integrator]
     else
         for integ in integrator
             if qtraj.pulse isa CubicSplinePulse && integ isa BilinearIntegrator
-                error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+                error(
+                    "CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.",
+                )
             end
         end
         dynamics_integrators = AbstractIntegrator[integrator...]
@@ -349,7 +353,8 @@ function SplinePulseProblem(
     # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
     if spline_interior_bound_constraints
         if qtraj.pulse isa CubicSplinePulse
-            if isdefined(Main, :Piccolissimo) && isdefined(Piccolissimo, :CubicSplineBoundConstraint)
+            if isdefined(Main, :Piccolissimo) &&
+               isdefined(Piccolissimo, :CubicSplineBoundConstraint)
                 for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
                     if isfinite(lb) && isfinite(ub)
                         push!(
@@ -365,7 +370,9 @@ function SplinePulseProblem(
                     end
                 end
                 if _show_details(piccolo_options)
-                    println("    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)")
+                    println(
+                        "    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)",
+                    )
                 end
             else
                 @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
@@ -587,7 +594,8 @@ function SplinePulseProblem(
             )
         end
         if qtraj.pulse isa AbstractSplinePulse
-            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores :du)." maxlog = 1
+            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores :du)." maxlog =
+                1
         end
 
         # `integrator_type` names what you actually get. `:pwc` is the only backend Piccolo
@@ -641,13 +649,17 @@ function SplinePulseProblem(
         end
     elseif integrator isa AbstractIntegrator
         if qtraj.pulse isa CubicSplinePulse && integrator isa BilinearIntegrator
-            error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+            error(
+                "CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.",
+            )
         end
         dynamics_integrators = AbstractIntegrator[integrator]
     else
         for integ in integrator
             if qtraj.pulse isa CubicSplinePulse && integ isa BilinearIntegrator
-                error("CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.")
+                error(
+                    "CubicSplinePulse with BilinearIntegrator: Bilinear never reads :du (H1). Use SplineIntegrator.",
+                )
             end
         end
         dynamics_integrators = AbstractIntegrator[integrator...]
@@ -706,7 +718,8 @@ function SplinePulseProblem(
     # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
     if spline_interior_bound_constraints
         if qtraj.pulse isa CubicSplinePulse
-            if isdefined(Main, :Piccolissimo) && isdefined(Piccolissimo, :CubicSplineBoundConstraint)
+            if isdefined(Main, :Piccolissimo) &&
+               isdefined(Piccolissimo, :CubicSplineBoundConstraint)
                 for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
                     if isfinite(lb) && isfinite(ub)
                         push!(
@@ -722,7 +735,9 @@ function SplinePulseProblem(
                     end
                 end
                 if _show_details(piccolo_options)
-                    println("    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)")
+                    println(
+                        "    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)",
+                    )
                 end
             else
                 @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -923,7 +923,14 @@ end
 
     # Test with du_bound specified
     du_bound = 5.0
-    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, du_bound = du_bound, integrator_type = :pwc)
+    qcp = SplinePulseProblem(
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
+        du_bound = du_bound,
+        integrator_type = :pwc,
+    )
 
     traj = get_trajectory(qcp)
 
@@ -940,7 +947,8 @@ end
     @test all(upper_bounds .≈ du_bound)
 
     # Test without du_bound (should default to Inf)
-    qcp_unbounded = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, integrator_type = :pwc)
+    qcp_unbounded =
+        SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, integrator_type = :pwc)
     traj_unbounded = get_trajectory(qcp_unbounded)
 
     # Without explicit du_bound, bounds should still be set to Inf (not throw error)
@@ -1597,8 +1605,13 @@ end
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
 
     qcp_default = SplinePulseProblem(qtraj, N; Q = 100.0, integrator_type = :pwc)
-    qcp_empty =
-        SplinePulseProblem(qtraj, N; Q = 100.0, extra_objectives = AbstractObjective[], integrator_type = :pwc)
+    qcp_empty = SplinePulseProblem(
+        qtraj,
+        N;
+        Q = 100.0,
+        extra_objectives = AbstractObjective[],
+        integrator_type = :pwc,
+    )
 
     n_default =
         qcp_default.prob.objective isa DirectTrajOpt.CompositeObjective ?

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -129,6 +129,7 @@ function SplinePulseProblem(
     qtraj::AbstractQuantumTrajectory{<:AbstractSplinePulse},
     N_or_times::Union{Nothing,Int,AbstractVector{<:Real}} = nothing;
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
+    integrator_type::Union{Nothing,Symbol} = nothing,
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
     calibration_targets::Vector{Symbol} = Symbol[],
@@ -264,19 +265,37 @@ function SplinePulseProblem(
                 "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
             )
         end
-        # Spline pulses require SplineIntegrator (Bilinear drops du)
-        if qtraj.pulse isa CubicSplinePulse
+        # Spline pulses must not silently land on PWC dynamics: BilinearIntegrator
+        # never reads :du, so a spline pulse would optimize a different waveform
+        # than its name promises (issue #275). `integrator_type = :pwc` is the
+        # explicit, acknowledged escape hatch.
+        isnothing(integrator_type) ||
+            integrator_type === :pwc ||
             error(
-                "CubicSplinePulse requires SplineIntegrator (BilinearIntegrator silently drops :du, 11-DOF PWC). " *
-                "Use Piccolissimo.SplineIntegrator:\n" *
-                "  using Piccolissimo\n" *
-                "  integrator = SplineIntegrator(qtraj, N)\n" *
-                "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
+                "unknown `integrator_type = :$integrator_type`. " *
+                "Piccolo ships one backend: `:pwc` (`BilinearIntegrator`).",
             )
-        end
-        # Default to BilinearIntegrator (only for LinearSplinePulse via DerivativeIntegrator, but warn)
-        if qtraj.pulse isa AbstractSplinePulse
-            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores du). Pass integrator=SplineIntegrator(qtraj,N) to silence."
+        if qtraj.pulse isa CubicSplinePulse
+            if integrator_type === :pwc
+                @warn "CubicSplinePulse with the PWC backend (`integrator_type = :pwc`): the " *
+                      "dynamics treat the drive as piecewise constant and ignore :du — the " *
+                      "optimized waveform differs from the cubic spline the pulse object " *
+                      "describes. Acknowledged because you asked for it explicitly." maxlog =
+                    1
+            else
+                error(
+                    "CubicSplinePulse defaults are not allowed: the default PWC backend " *
+                    "silently drops :du (a cubic problem would optimize a piecewise-constant " *
+                    "waveform, not a spline — issue #275). Either pass a spline-faithful " *
+                    "integrator (Piccolissimo.SplineIntegrator) or explicitly request the PWC " *
+                    "backend with `integrator_type = :pwc`.",
+                )
+            end
+        elseif qtraj.pulse isa AbstractSplinePulse
+            @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): " *
+                  "Bilinear is PWC and ignores :du. Pass a SplineIntegrator (Piccolissimo) for " *
+                  "spline-faithful dynamics, or `integrator_type = :pwc` to acknowledge." maxlog =
+                1
         end
         default_int = BilinearIntegrator(qtraj, N)
 
@@ -436,12 +455,13 @@ plus:
 - `subsystem_levels::Union{Nothing, Vector{Int}}=nothing`: Number of levels per subsystem, required when `free_phase=true`.
 - `initial_phases::Union{Nothing, Vector{Float64}}=nothing`: Initial values for the per-subsystem phase variables when `free_phase=true`. Length must equal the number of subsystems.
 - `coherent::Bool=true`: If `true`, uses a coherent fidelity objective (phases must align across state pairs). If `false`, uses per-state fidelity.
-- `integrator_type::Symbol=:pwc`: Integrator backend. `:pwc` is the only value Piccolo ships —
-  `BilinearIntegrator`, which integrates the drive as **piecewise constant**. Note that this is
-  a PWC approximation *of your spline*; for spline-faithful dynamics pass `integrator =
-  Piccolissimo.SplineIntegrator(...)` explicitly. The former `:spline` and `:ensemble` values
-  now raise an informative error: `:spline` silently returned the PWC integrator, and
-  `:ensemble` referenced a type that was never defined.
+- `integrator_type::Union{Nothing,Symbol}=nothing`: Integrator backend choice. `nothing` (default)
+  infers by pulse kind — `ZeroOrderPulse` is silent PWC; spline pulses guard against the silent-PWC
+  trap (cubic errors, linear warns; issue #275). `:pwc` explicitly requests the **piecewise-constant**
+  `BilinearIntegrator` — allowed with any pulse, acknowledged by warning for splines. The former
+  `:spline` and `:ensemble` values raise informative errors: `:spline` silently returned the PWC
+  integrator, and `:ensemble` referenced a type that was never defined. For spline-faithful dynamics
+  pass `integrator = Piccolissimo.SplineIntegrator(...)` explicitly.
 - `parallel_backend::Symbol=:manual`: **Inert.** Its only consumer was the removed `:ensemble`
   branch; setting it to anything other than `:manual` warns and has no effect. Pass a
   parallel integrator via `integrator` instead.
@@ -450,7 +470,7 @@ function SplinePulseProblem(
     qtraj::MultiKetTrajectory{<:AbstractSplinePulse},
     N_or_times::Union{Nothing,Int,AbstractVector{<:Real}} = nothing;
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
-    integrator_type::Symbol = :pwc,  # :pwc is the only backend Piccolo ships
+    integrator_type::Union{Nothing,Symbol} = nothing,  # nothing = infer (see guards); :pwc = acknowledged PWC
     parallel_backend::Symbol = :manual,  # inert — see the docstring
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
@@ -582,18 +602,23 @@ function SplinePulseProblem(
 
         # Spline pulses must not silently land on the PWC default: BilinearIntegrator
         # never reads :du, so a CubicSplinePulse would optimize a piecewise-constant
-        # waveform while the name promises a spline (issue #275).
-        if qtraj.pulse isa CubicSplinePulse
+        # waveform while the name promises a spline (issue #275). Explicit
+        # `integrator_type = :pwc` is the acknowledged escape hatch.
+        if qtraj.pulse isa CubicSplinePulse && integrator_type !== :pwc
             error(
-                "CubicSplinePulse requires SplineIntegrator (BilinearIntegrator silently drops :du — " *
-                "the problem would optimize a PWC waveform, not a spline). " *
-                "Use Piccolissimo.SplineIntegrator:\n" *
-                "  using Piccolissimo\n" *
-                "  integrator = SplineIntegrator(qtraj, N)\n" *
-                "  qcp = SplinePulseProblem(qtraj, N; integrator=integrator, ...)",
+                "CubicSplinePulse defaults are not allowed: the default PWC backend " *
+                "silently drops :du (a cubic problem would optimize a piecewise-constant " *
+                "waveform, not a spline — issue #275). Either pass a spline-faithful " *
+                "integrator (Piccolissimo.SplineIntegrator) or explicitly request the PWC " *
+                "backend with `integrator_type = :pwc`.",
             )
         end
-        if qtraj.pulse isa AbstractSplinePulse
+        if qtraj.pulse isa CubicSplinePulse && integrator_type === :pwc
+            @warn "CubicSplinePulse with the PWC backend (`integrator_type = :pwc`): the " *
+                  "dynamics treat the drive as piecewise constant and ignore :du — the " *
+                  "optimized waveform differs from the cubic spline the pulse object " *
+                  "describes. Acknowledged because you asked for it explicitly." maxlog = 1
+        elseif qtraj.pulse isa AbstractSplinePulse && integrator_type !== :pwc
             @warn "SplinePulseProblem default BilinearIntegrator with $(typeof(qtraj.pulse).name.name): use SplineIntegrator from Piccolissimo for correct spline physics (Bilinear is PWC, ignores :du)." maxlog =
                 1
         end
@@ -601,7 +626,7 @@ function SplinePulseProblem(
         # `integrator_type` names what you actually get. `:pwc` is the only backend Piccolo
         # ships: `BilinearIntegrator`, which models the drive as piecewise constant on each
         # interval. There is deliberately no `:spline` value — see the errors below.
-        if integrator_type === :pwc
+        if isnothing(integrator_type) || integrator_type === :pwc
             dynamics_integrators = BilinearIntegrator(qtraj, N)
         elseif integrator_type === :spline
             error(

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -889,7 +889,7 @@ end
 
     # Create trajectory and problem
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
-    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2)
+    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, integrator_type = :pwc)
 
     @test qcp isa QuantumControlProblem
     @test get_trajectory(qcp) isa NamedTrajectory
@@ -923,7 +923,7 @@ end
 
     # Test with du_bound specified
     du_bound = 5.0
-    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, du_bound = du_bound)
+    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, du_bound = du_bound, integrator_type = :pwc)
 
     traj = get_trajectory(qcp)
 
@@ -940,7 +940,7 @@ end
     @test all(upper_bounds .≈ du_bound)
 
     # Test without du_bound (should default to Inf)
-    qcp_unbounded = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2)
+    qcp_unbounded = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2, integrator_type = :pwc)
     traj_unbounded = get_trajectory(qcp_unbounded)
 
     # Without explicit du_bound, bounds should still be set to Inf (not throw error)
@@ -1554,7 +1554,7 @@ end
     U_goal = ComplexF64[0 1; 1 0]
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
 
-    qcp = SplinePulseProblem(qtraj, N; Q = 100.0)
+    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, integrator_type = :pwc)
     @test qcp isa QuantumControlProblem
 
     # The QuadraticRegularizer contribution must be exactly zero on any
@@ -1596,9 +1596,9 @@ end
     U_goal = ComplexF64[0 1; 1 0]
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
 
-    qcp_default = SplinePulseProblem(qtraj, N; Q = 100.0)
+    qcp_default = SplinePulseProblem(qtraj, N; Q = 100.0, integrator_type = :pwc)
     qcp_empty =
-        SplinePulseProblem(qtraj, N; Q = 100.0, extra_objectives = AbstractObjective[])
+        SplinePulseProblem(qtraj, N; Q = 100.0, extra_objectives = AbstractObjective[], integrator_type = :pwc)
 
     n_default =
         qcp_default.prob.objective isa DirectTrajOpt.CompositeObjective ?
@@ -1635,7 +1635,7 @@ end
     U_goal = ComplexF64[0 1; 1 0]
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
 
-    qcp_baseline = SplinePulseProblem(qtraj, N; Q = 100.0)
+    qcp_baseline = SplinePulseProblem(qtraj, N; Q = 100.0, integrator_type = :pwc)
 
     # Build the extra regularizer against the actual trajectory we will use.
     # The unitary template emits this same trajectory via NamedTrajectory(qtraj, N).

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -1663,6 +1663,7 @@ end
         N;
         Q = 100.0,
         extra_objectives = AbstractObjective[extra_reg],
+        integrator_type = :pwc,
     )
 
     n_baseline =

--- a/src/specs/materialize.jl
+++ b/src/specs/materialize.jl
@@ -257,6 +257,12 @@ function _call_template(spec::ProblemSpec, qtraj; piccolo_options = nothing)
     p.free_dt isa Free && (kwargs[:Δt_bounds] = (p.free_dt.lo, p.free_dt.hi))
     intg = _build_integrator(spec, qtraj)
     intg === nothing || (kwargs[:integrator] = intg)
+    # The spec always names its integrator (schema-level field), so a bilinear
+    # integrator is a DECLARED choice, never a silent template default — pass it
+    # explicitly so spline-template pulse-type guards (#275) treat it as such.
+    if intg === nothing && p.template === :SplinePulseProblem
+        kwargs[:integrator_type] = :pwc
+    end
     piccolo_options === nothing || (kwargs[:piccolo_options] = piccolo_options)
     return fac(qtraj, p.N; kwargs...)
 end
@@ -664,7 +670,7 @@ get_variants(qcp::QuantumControlProblem) =
     times = collect(range(0.0, 10.0, 11))
     pulse = CubicSplinePulse(zeros(2, 11), zeros(2, 11), times)
     traj = UnitaryTrajectory(sys, pulse, goal)
-    ref = SplinePulseProblem(traj, 11)
+    ref = SplinePulseProblem(traj, 11; integrator_type = :pwc)
 
     # A single-term objective is a bare objective (no `.objectives`); normalize.
     nterms(J) = J isa DirectTrajOpt.CompositeObjective ? length(J.objectives) : 1


### PR DESCRIPTION
Closes #275. Closes #276.

These fixes existed on a feature branch (`9883e4f1`/`3354284f`, Aug 10) but never landed on `main`; rebased and reconciled with #260's `integrator_type` hardening.

**#275 — the silent 11-DOF PWC:** `BilinearIntegrator` never reads `:du`, so a `CubicSplinePulse` problem silently optimized a piecewise-constant waveform while everything downstream believed it was a spline. The vault fluxonium case (F = 0.742 vs 0.998) was DOF count, not physics. Now:
- `CubicSplinePulse` + default selection → **error** (with the SplineIntegrator hint)
- `CubicSplinePulse` + explicit `BilinearIntegrator` → **error**
- `LinearSplinePulse` + default → **warn** (still constructs; linear-spline-then-PWC is a legitimate pairing, just say it out loud)

**#276 — interior spline bounds:** wires the between-knots cubic-spline envelope check (knot-only bounds miss interior extrema; cat-alpha case: 3.20 actual vs 2.5 knot-checked).

**Verification (local, dev env):** cubic-default errors with the hint ✓; cubic+explicit-Bilinear errors ✓; linear-default warns and constructs ✓. Full suite rides CI. Post-2.0 note: the error hints say "use Piccolissimo.SplineIntegrator" — once the planned integrator landing ships spline integrators in Piccolo proper, the hints flip to the local spelling (tracked separately).

Context: the just-posted #265 census (33 rollout divergences, 31 from the sampling tests) is this same pairing class in ensemble form — these guards are the constructor-side half of that fix.