### PR TITLE
docs: notation pass — knot points (nodes) for N, timestep reserved for Δt

### DIFF
--- a/docs/literate/first_gate.jl
+++ b/docs/literate/first_gate.jl
@@ -61,7 +61,7 @@ sys.levels, sys.n_drives
 
 ## Gate duration and discretization
 T = 10.0   # Total time (in units where ω = 1)
-N = 100    # Number of timesteps
+N = 100    # Number of knot points
 
 ## Time vector
 times = collect(range(0, T, length = N))

--- a/docs/literate/getting-started/concepts.jl
+++ b/docs/literate/getting-started/concepts.jl
@@ -109,13 +109,30 @@ fidelity(qcp)
 # - **R = 0.1**: Very smooth pulses
 # - **R = 1e-4**: Allow aggressive controls
 #
-# ### Number of Timesteps (N)
+# ### Number of Knot Points (N)
 #
-# `N` is the discretization resolution:
+# `N` is the discretization resolution — the number of knot points (nodes, in the
+# direct multiple-shooting literature) at which the trajectory is discretized:
 #
 # - **N = 50**: Coarse, fast optimization
 # - **N = 100**: Typical
 # - **N = 200+**: Fine control, slower
+#
+# ### Notation
+#
+# Throughout the Piccolo ecosystem the notation is aligned with the direct
+# multiple-shooting literature:
+#
+# - **N** — the number of knot points (nodes); `traj.N`. Prose says "knot
+#   points" at first mention, "knots" thereafter.
+# - **T** — the total pulse duration (a scalar).
+# - **Δt_k** — the timestep of knot `k` (the `:Δt` trajectory component; on a
+#   uniform grid `T = N·Δt`). The word "timestep" always means this per-knot
+#   quantity, never the count.
+# - **u(t)** — the control/drive amplitudes; **Ũ̃/ψ̃** — real-vector-isomorphism
+#   states.
+# - A **piecewise-constant (zero-order hold)** drive is one value of `u` per
+#   knot; spline drives interpolate between knots.
 #
 # ## Common Patterns
 #

--- a/docs/literate/quickstart.jl
+++ b/docs/literate/quickstart.jl
@@ -41,7 +41,7 @@ sys = QuantumSystem(H_drift, H_drives, drive_bounds)
 
 ## Time parameters
 T = 10.0   # Total gate duration
-N = 100    # Number of timesteps
+N = 100    # Number of knot points
 
 ## Create time vector
 times = collect(range(0, T, length = N))

--- a/docs/literate/reference/visualizations.jl
+++ b/docs/literate/reference/visualizations.jl
@@ -243,7 +243,7 @@ control_values = traj[:u]
 
 # Trajectory data:
 
-println("Number of timesteps: ", length(timesteps))
+println("Number of knots: ", length(timesteps))
 println("Total duration: ", sum(timesteps))
 println("Control array size: ", size(control_values)) # nothing
 

--- a/docs/literate/two_qubit_gate_validation.jl
+++ b/docs/literate/two_qubit_gate_validation.jl
@@ -183,7 +183,7 @@ cached_solve!(qcp_lin, "two_qubit_linear_spline"; max_iter = 80)
 # !!! note "Number of Timesteps"
 #     The discretized dynamics constraints of the optimizer are not exact when
 #     the control pulses are not piecewise-constant. Consequently, the number of
-#     timesteps may need to be increased, depending the degree of physical
+#     knot points may need to be increased, depending the degree of physical
 #     accuracy needed. If the discretized dynamics are not accurate, the
 #     optimizer may maximize the fidelity for the *discretized* dynamics, while
 #     the actual fidelity for the real, *continuous-time* dynamics is not as
@@ -207,7 +207,7 @@ lin_traj = get_trajectory(qcp_lin)
 pulse_cub = CubicSplinePulse(lin_traj[:u], zero(lin_traj[:u]), get_times(lin_traj))
 qtraj_cub = UnitaryTrajectory(sys, pulse_cub, U_goal)
 
-# We now perform the optimization, again noting that the number of timesteps
+# We now perform the optimization, again noting that the number of knot points
 # may need to be adjusted for greater physical accuracy.
 
 N_timesteps_cub = N_params

--- a/docs/literate/two_qubit_gate_validation.jl
+++ b/docs/literate/two_qubit_gate_validation.jl
@@ -180,7 +180,7 @@ qcp_lin = SplinePulseProblem(
 
 cached_solve!(qcp_lin, "two_qubit_linear_spline"; max_iter = 80)
 
-# !!! note "Number of Timesteps"
+# !!! note "Number of Knot Points"
 #     The discretized dynamics constraints of the optimizer are not exact when
 #     the control pulses are not piecewise-constant. Consequently, the number of
 #     knot points may need to be increased, depending the degree of physical

--- a/src/control/CONTEXT.md
+++ b/src/control/CONTEXT.md
@@ -32,7 +32,7 @@ T = 10.0  # duration
 qtraj = UnitaryTrajectory(sys, U_goal, T)  # creates zero pulse internally
 
 # 3. Build optimization problem
-N = 51  # number of timesteps
+N = 51  # number of knot points
 qcp = SmoothPulseProblem(qtraj, N; Q=100.0, R=1e-2)
 
 # 4. Solve (use 'options' keyword for IpoptOptions)

--- a/src/control/templates/bang_bang_pulse_problem.jl
+++ b/src/control/templates/bang_bang_pulse_problem.jl
@@ -21,7 +21,7 @@ At optimality, ``s = |du|``, giving the exact L1 norm.
 
 # Arguments
 - `qtraj::AbstractQuantumTrajectory{<:ZeroOrderPulse}`: Quantum trajectory with piecewise constant pulse
-- `N::Int`: Number of timesteps for discretization
+- `N::Int`: number of knot points for discretization
 
 # Keyword Arguments
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, uses BilinearIntegrator.

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -79,7 +79,7 @@ The problem adds discrete derivative variables (du, ddu) that:
 
 # Arguments
 - `qtraj::AbstractQuantumTrajectory{<:ZeroOrderPulse}`: Quantum trajectory with piecewise constant pulse
-- `N::Int`: Number of timesteps for discretization
+- `N::Int`: number of knot points for discretization
 
 # Keyword Arguments
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, uses BilinearIntegrator (which does not support global variables). A custom integrator is required when `global_names` is specified.
@@ -315,7 +315,7 @@ use `SplinePulseProblem` instead.
 
 # Arguments
 - `qtraj::MultiKetTrajectory{<:ZeroOrderPulse}`: Ensemble of ket state transfers with piecewise constant pulse
-- `N::Int`: Number of timesteps for the discretization
+- `N::Int`: number of knot points for the discretization
 
 # Keyword Arguments
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, the default `BilinearIntegrator` is used. When `global_names` is specified, you must supply a custom integrator here (i.e., do not rely on the default `BilinearIntegrator`) that supports global variables.

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -211,7 +211,7 @@ function SplinePulseProblem(
     # N_or_times=nothing uses native pulse knot times (preserves warm-start exactly)
     base_traj =
         NamedTrajectory(qtraj, N_or_times; Δt_bounds = Δt_bounds, global_data = global_data)
-    N = base_traj.N  # Get actual number of timesteps
+    N = base_traj.N  # Get actual number of knot points
 
     # Always add control derivatives to trajectory
     # For CubicSplinePulse, :du is already included in the base trajectory (Hermite tangents)
@@ -460,7 +460,7 @@ function SplinePulseProblem(
     # N_or_times=nothing uses native pulse knot times (preserves warm-start exactly)
     base_traj =
         NamedTrajectory(qtraj, N_or_times; Δt_bounds = Δt_bounds, global_data = global_data)
-    N = base_traj.N  # Get actual number of timesteps
+    N = base_traj.N  # Get actual number of knot points
 
     # Always add control derivatives to trajectory
     # For CubicSplinePulse, :du is already included in the base trajectory (Hermite tangents)

--- a/src/quantum/dynamics.jl
+++ b/src/quantum/dynamics.jl
@@ -1068,7 +1068,7 @@ end
     global_params = (δ = 0.5, Ω = 1.0)
     sys = QuantumSystem(H_drives, [1.0, 1.0]; global_params = global_params)
 
-    # Create a unitary trajectory (2 drives × 2 timesteps)
+    # Create a unitary trajectory (2 drives × 2 knot points)
     pulse = ZeroOrderPulse([0.5 0.3; 0.5 0.3], [0.0, 1.0])
     U_goal = PAULIS[:X]
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)

--- a/src/quantum/trajectories/rollouts_extensions.jl
+++ b/src/quantum/trajectories/rollouts_extensions.jl
@@ -1311,7 +1311,7 @@ end
     system = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
     X_gate = ComplexF64[0 1; 1 0]
 
-    # Create trajectory with initial pulse (1 drive × 2 timesteps)
+    # Create trajectory with initial pulse (1 drive × 2 knot points)
     pulse1 = ZeroOrderPulse([0.5 0.5], [0.0, 1.0])
     qtraj = UnitaryTrajectory(system, pulse1, X_gate)
     @test length(qtraj.solution.u) == 101

--- a/src/quantum/trajectories/sampling_trajectory.jl
+++ b/src/quantum/trajectories/sampling_trajectory.jl
@@ -169,7 +169,7 @@ a different system (e.g., parameter variations), but all share the same controls
 # Create sampling trajectory with 3 system variations
 sampling = SamplingTrajectory(base_qtraj, [sys1, sys2, sys3])
 
-# Convert to NamedTrajectory with 51 timesteps
+# Convert to NamedTrajectory with 51 knot points
 traj = NamedTrajectory(sampling, 51)
 # Result has: :Ũ⃗1, :Ũ⃗2, :Ũ⃗3, :u, :Δt, :t
 ```


### PR DESCRIPTION
Closes #284.

The Piccolo side of the stack-wide verbiage alignment (umbrella Piccolissimo #423; N retained as the node count per the multiple-shooting literature — the cancelled N→K rename's lesson, now applied to words instead of identifiers).

**The convention** (canonical `### Notation` block added to the concepts guide): **N** = number of knot points (nodes, direct multiple-shooting vocabulary) — prose says "knot points" at first mention, "knots" after; **"timestep"** exclusively = the per-knot Δt_k (the `:Δt` component), never the count; **T** = total duration; piecewise-constant (zero-order hold) spelled out at first use.

**Changed:** src docstrings/comments (templates, CONTEXT.md, dynamics, trajectories — count-sense "timesteps" → "knot points"), tutorial comments (`N = 100  # number of knot points`), the concepts guide section heading + Notation block, two literate-guide wordings. `docs/build/` untouched (regenerates).

**Zero identifiers, zero API, zero wire-format impact.** Sibling PRs carrying the same convention: DirectTrajOpt #131, NamedTrajectories #147, Piccolissimo #439.