### PR TITLE
feat: forward SolveStats through QuantumControlProblem.solve!

### DIFF
--- a/src/control/problems.jl
+++ b/src/control/problems.jl
@@ -401,6 +401,10 @@ Solve the quantum control problem by forwarding to the inner DirectTrajOptProble
 - `divergence_rtol::Real=ROLLOUT_DIVERGENCE_RTOL[]`: Relative tolerance for that check.
 
 All other keyword arguments are passed to the DirectTrajOpt solver.
+
+Returns `DirectTrajOpt.Solvers.SolveStats` (termination status, raw status string,
+NLP objective, IPM iterations, solve wall time, solver symbol) once DirectTrajOpt
+provides it; `nothing` until then.
 """
 function solve!(
     qcp::QuantumControlProblem;
@@ -410,7 +414,11 @@ function solve!(
     divergence_rtol::Real = ROLLOUT_DIVERGENCE_RTOL[],
     kwargs...,
 )
-    solve!(qcp.prob; verbose = verbose, kwargs...)
+    # SolveStats (status, iterations, objective, wall time) from the backend —
+    # returned AFTER the trajectory sync so callers get data describing the
+    # trajectory they actually hold. (Returns nothing until DirectTrajOpt's
+    # registry release carries the SolveStats return.)
+    stats = solve!(qcp.prob; verbose = verbose, kwargs...)
     if sync
         sync_trajectory!(
             qcp;
@@ -418,7 +426,7 @@ function solve!(
             divergence_rtol = divergence_rtol,
         )
     end
-    return nothing
+    return stats
 end
 
 # Forward other common DirectTrajOptProblem accessors


### PR DESCRIPTION
From the API review (#287); the DirectTrajOpt side is #133.

`solve!(qcp)` now returns the backend's `SolveStats` after the trajectory sync — status, raw status string, NLP objective, IPM iterations, wall time, solver symbol — instead of `nothing`.

**Forward-compatible:** against the current registry DirectTrajOpt this returns `nothing` exactly as before; it becomes live when DirectTrajOpt's next release (carrying #133) resolves. Merge whenever — no ordering constraint.