### PR TITLE
release: Piccolo v2.0.0 — version bump + CHANGELOG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.21.0"
+version = "2.0.0"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]

--- a/docs/src/development/release-notes.md
+++ b/docs/src/development/release-notes.md
@@ -2,6 +2,51 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.0] - 2026-08-18
+
+The multiple-shooting notation release: **N stays N** — the number of knot
+points (nodes), aligned with the direct multiple-shooting literature — and
+the API stops pretending silent defaults are safe.
+
+### Removed (breaking)
+
+- **`PiccoloOptions` inert fields removed** — `rollout_integrator`, `geodesic`,
+  `zero_initial_and_final_derivative` were stored but never consulted
+  (removal publicly promised since v1.x, #255/#283). Constructing with these
+  kwargs now errors.
+- **`SplinePulseProblem` no longer silently defaults spline pulses to
+  piecewise-constant dynamics** (#275, #282): `BilinearIntegrator` never reads
+  `:du`, so a `CubicSplinePulse` problem was optimizing a different waveform
+  than its name promised (measured: optimizer-reported ~1e-8 infidelity for
+  pulses that actually achieve ~1e-3). Cubic-spline problems must now either
+  pass a spline-faithful integrator (`Piccolissimo.SplineIntegrator`) or
+  explicitly request the PWC backend with `integrator_type = :pwc` (which
+  warns). Linear-spline problems warn on the default. The deprecated
+  `integrator_type = :spline` (which silently returned the PWC integrator)
+  and `:ensemble` (never implemented) now raise informative errors.
+
+### Added
+
+- **Cubic-spline interior bounds** (#276): the between-knots spline envelope
+  is now constrained (knot-only bounds miss interior extrema).
+- **`solve!` returns `SolveStats`** — termination status, raw status string,
+  NLP objective, IPM iterations, solve wall time, solver symbol (forwarded
+  through `QuantumControlProblem.solve!`; live once DirectTrajOpt's next
+  release lands).
+- **`Piccolo.Specs` frozen wire-format corpus** (`test/specs_corpus/`) — the
+  canonical ProblemSpec projection with recorded structure/problem hashes and
+  a byte-stability test; the wire format is now frozen by CI.
+- **Canonical Notation section** in the concepts guide: **N** = number of knot
+  points (nodes); **"timestep"** exclusively the per-knot Δt_k; **T** =
+  duration; PWC = piecewise-constant (zero-order hold).
+
+### Fixed
+
+- `RolloutStates`/sampling coverage: divergent pairings surface loudly
+  (`rollout_divergence`); the constructor-side guards above are the fix.
+- `workflow_dispatch` triggers on CI and Documentation workflows (retrigger
+  without a push).
+
 ## [v1.0.0] - Upcoming
 
 ### Changed


### PR DESCRIPTION
Closes #290.

**Piccolo 2.0.0** — the notation-and-honesty release. Everything in it is already merged and green on main; this PR carries only the `Project.toml` bump (1.21.0 → 2.0.0) and the release notes.

**Breaking (as merged):**
- #283 — inert `PiccoloOptions` fields removed (`rollout_integrator`, `geodesic`, `zero_initial_and_final_derivative`; never consulted; removal publicly promised)
- #282 — `SplinePulseProblem` errors on undeclared cubic+PWC pairing; `integrator_type = :pwc` is the acknowledged escape hatch; `#276` interior spline bounds ride along

**Added:** SolveStats return (#288), the frozen Specs corpus (#281 — wire format now CI-frozen), the canonical Notation section (#285), dispatch-triggered CI workflows.

**Deliberately not in 2.0.0** (rides 2.1 per the program's release re-factoring): the integrator extraction from Piccolissimo, Specs Phase 2 core, geodesic init revival, plotting overhaul. The N→K rename was **cancelled** — N is the node count, per the direct multiple-shooting literature.

Umbrella: harmoniqs/Piccolissimo.jl#423. On merge, TagBot tags and the General registration follows.