### PR TITLE
test(coverage): Weyl chamber (0% → ~95%) + rollout variants (66.6% → ~97%) [cluster A]

### DIFF
--- a/src/quantum/trajectories/rollouts_extensions.jl
+++ b/src/quantum/trajectories/rollouts_extensions.jl
@@ -1337,6 +1337,13 @@ end
     # Roll out with different algorithm
     qtraj_rk = rollout(qtraj, pulse2; algorithm = Tsit5())
     @test length(qtraj_rk.solution.u) == 101
+
+    # In-place variants
+    rollout!(qtraj; n_save = 41)
+    @test length(qtraj.solution.u) == 41
+    rollout!(qtraj, pulse2)
+    @test qtraj.pulse === pulse2
+    @test length(qtraj.solution.u) == 101
 end
 
 @testitem "rollout - KetTrajectory" begin
@@ -1357,6 +1364,20 @@ end
 
     @test length(qtraj_new.solution.u) == 201
     @test qtraj_new.pulse === pulse2
+
+    # In-place variants
+    rollout!(qtraj, pulse2)
+    @test qtraj.pulse === pulse2
+    @test length(qtraj.solution.u) == 101
+    rollout!(qtraj; n_save = 41)
+    @test length(qtraj.solution.u) == 41
+
+    # Same-pulse re-solve returns a NEW trajectory
+    qtraj_resolved = rollout(qtraj; n_save = 41)
+    @test qtraj_resolved isa KetTrajectory
+    @test qtraj_resolved !== qtraj
+    @test length(qtraj_resolved.solution.u) == 41
+    @test qtraj_resolved.pulse === qtraj.pulse
 end
 
 @testitem "rollout preserves MultiKetTrajectory solution structure" begin
@@ -1404,6 +1425,21 @@ end
 
     @test length(qtraj_new.solution.u) == 2
     @test qtraj_new.pulse === pulse2
+
+    # In-place variants
+    rollout!(qtraj, pulse2)
+    @test qtraj.pulse === pulse2
+    @test length(qtraj.solution.u) == 2
+    rollout!(qtraj; n_save = 41)
+    @test length(qtraj.solution.u) == 2
+    @test length(qtraj.solution.u[1].t) == 41
+
+    # Same-pulse re-solve returns a NEW trajectory
+    qtraj_resolved = rollout(qtraj; n_save = 41)
+    @test qtraj_resolved isa MultiKetTrajectory
+    @test qtraj_resolved !== qtraj
+    @test length(qtraj_resolved.solution.u) == 2
+    @test qtraj_resolved.weights == qtraj.weights
 end
 
 @testitem "rollout - DensityTrajectory" begin
@@ -1425,6 +1461,21 @@ end
 
     @test length(qtraj_new.solution.u) == 301
     @test qtraj_new.pulse === pulse2
+
+    # In-place variants
+    rollout!(qtraj, pulse2)
+    @test qtraj.pulse === pulse2
+    @test length(qtraj.solution.u) == 101
+    rollout!(qtraj; n_save = 41)
+    @test length(qtraj.solution.u) == 41
+    rollout!(qtraj; algorithm = nothing)  # falls back to default_algorithm(::OpenQuantumSystem)
+    @test length(qtraj.solution.u) == 101
+
+    # Same-pulse re-solve returns a NEW trajectory
+    qtraj_resolved = rollout(qtraj; n_save = 41)
+    @test qtraj_resolved isa DensityTrajectory
+    @test qtraj_resolved !== qtraj
+    @test length(qtraj_resolved.solution.u) == 41
 end
 
 @testitem "fidelity with EmbeddedOperator uses Pedersen formula" begin
@@ -1491,4 +1542,147 @@ end
     # With explicit subspace
     fid_sub = fidelity(qtraj; subspace = [1, 2])
     @test 0.0 <= fid_sub <= 1.0
+end
+
+@testitem "rollout - MultiDensityTrajectory" begin
+    using LinearAlgebra
+
+    L = ComplexF64[0.1 0.0; 0.0 0.0]
+    system = OpenQuantumSystem(PAULIS.Z, [PAULIS.X], [1.0]; dissipation_operators = [L])
+
+    ρ0s = [ComplexF64[1.0 0.0; 0.0 0.0], ComplexF64[0.0 0.0; 0.0 1.0]]
+    ρgs = [ComplexF64[0.0 0.0; 0.0 1.0], ComplexF64[1.0 0.0; 0.0 0.0]]
+
+    pulse1 = ZeroOrderPulse([0.5 0.5], [0.0, 1.0])
+    qtraj = MultiDensityTrajectory(system, pulse1, ρ0s, ρgs)
+
+    # Roll out a new pulse (non-mutating)
+    pulse2 = ZeroOrderPulse([0.8 0.8], [0.0, 1.0])
+    qtraj_new = rollout(qtraj, pulse2; n_save = 201)
+
+    @test qtraj_new isa MultiDensityTrajectory
+    @test qtraj_new !== qtraj
+    @test length(qtraj_new.solution.u) == 2
+    @test length(qtraj_new.solution.u[1].t) == 201
+    @test qtraj_new.pulse === pulse2
+    @test qtraj_new.system === qtraj.system
+    @test qtraj_new.initials == ρ0s
+    @test qtraj_new.goals == ρgs
+    @test qtraj_new.weights == qtraj.weights
+    @test 0.0 <= fidelity(qtraj_new) <= 1.0
+
+    # Same-pulse re-solve with new ODE parameters (non-mutating)
+    qtraj_fine = rollout(qtraj; n_save = 201)
+    @test qtraj_fine isa MultiDensityTrajectory
+    @test qtraj_fine.pulse === pulse1
+    @test length(qtraj_fine.solution.u) == 2
+
+    # In-place variants
+    rollout!(qtraj, pulse2)
+    @test qtraj.pulse === pulse2
+    @test length(qtraj.solution.u) == 2
+    rollout!(qtraj; n_save = 41)
+    @test length(qtraj.solution.u) == 2
+    @test length(qtraj.solution.u[1].t) == 41
+    rollout!(qtraj; algorithm = nothing)  # falls back to default_algorithm(::OpenQuantumSystem)
+    @test length(qtraj.solution.u) == 2
+end
+
+@testitem "fidelity warns and ignores phases for non-EmbeddedOperator goals" begin
+    using LinearAlgebra
+
+    # Plain matrix goal: `phases` cannot be applied — the kwarg must warn, not silently apply.
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
+    X_gate = ComplexF64[0 1; 1 0]
+    pulse = ZeroOrderPulse([0.5 0.5], [0.0, 1.0])
+    qtraj = UnitaryTrajectory(sys, pulse, X_gate)
+
+    f_unphased = fidelity(qtraj)
+    f_phased = @test_logs (:warn, r"phases` kwarg is ignored") match_mode = :any fidelity(
+        qtraj;
+        phases = [0.3],
+    )
+    @test f_phased ≈ f_unphased
+
+    # EmbeddedOperator goal with an explicit `subspace`: same warning, standard fidelity path.
+    H_drift_3 = ComplexF64[0 0 0; 0 1 0; 0 0 2]
+    H_drive_3 = ComplexF64[0 1 0; 1 0 1; 0 1 0] / √2
+    sys3 = QuantumSystem(H_drift_3, [H_drive_3], [1.0])
+    U_goal = EmbeddedOperator(X_gate, [1, 2], [3])
+    qt3 = UnitaryTrajectory(sys3, pulse, U_goal)
+
+    f_sub = @test_logs (:warn, r"phases` kwarg is ignored") match_mode = :any fidelity(
+        qt3;
+        subspace = [1, 2],
+        phases = [0.0],
+    )
+    @test 0.0 <= f_sub <= 1.0
+end
+
+@testitem "fidelity(::MultiKetTrajectory; phases) rotates goals coherently" begin
+    using LinearAlgebra
+
+    # Zero drift and zero controls: the states never move, so the phased coherent
+    # fidelity is hand-computable. With goals == initials only the |01⟩ goal picks up
+    # a phase, so F = |(1 + e^{-iθ₂})/2|² = cos²(θ₂/2) — independent of θ₁.
+    sys = QuantumSystem(zeros(ComplexF64, 4, 4), [kron(PAULIS[:X], PAULIS[:I])], [1.0])
+    ψa = ComplexF64[1, 0, 0, 0]
+    ψb = ComplexF64[0, 1, 0, 0]
+    pulse = ZeroOrderPulse(zeros(1, 2), [0.0, 1.0])
+    qtraj = MultiKetTrajectory(sys, pulse, [ψa, ψb], [ψa, ψb])
+
+    @test fidelity(qtraj) ≈ 1.0 atol = 1e-10
+    @test fidelity(qtraj; phases = [0.0, 0.0], subsystem_levels = [2, 2]) ≈ 1.0 atol = 1e-10
+    @test fidelity(qtraj; phases = [0.3, π / 2], subsystem_levels = [2, 2]) ≈ 0.5 atol =
+        1e-8
+    @test fidelity(qtraj; phases = [0.9, π / 2], subsystem_levels = [2, 2]) ≈ 0.5 atol =
+        1e-8
+
+    # phases without subsystem_levels is an assertion error
+    @test_throws AssertionError fidelity(qtraj; phases = [0.1, 0.2])
+end
+
+@testitem "Rollouts._update_system! swaps the system across trajectory types" begin
+    using LinearAlgebra
+
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
+    sys2 = QuantumSystem(0.9 * PAULIS.Z, [PAULIS.X], [1.0])
+    pulse = ZeroOrderPulse([0.5 0.5], [0.0, 1.0])
+
+    qtraj_u = UnitaryTrajectory(sys, pulse, GATES[:X])
+    Rollouts._update_system!(qtraj_u, sys2)
+    @test qtraj_u.system === sys2
+
+    ψ0 = ComplexF64[1.0, 0.0]
+    ψg = ComplexF64[0.0, 1.0]
+    qtraj_k = KetTrajectory(sys, pulse, ψ0, ψg)
+    Rollouts._update_system!(qtraj_k, sys2)
+    @test qtraj_k.system === sys2
+
+    qtraj_mk = MultiKetTrajectory(sys, pulse, [ψ0, ψg], [ψg, ψ0])
+    Rollouts._update_system!(qtraj_mk, sys2)
+    @test qtraj_mk.system === sys2
+
+    L = ComplexF64[0.1 0.0; 0.0 0.0]
+    osys = OpenQuantumSystem(PAULIS.Z, [PAULIS.X], [1.0]; dissipation_operators = [L])
+    osys2 =
+        OpenQuantumSystem(0.9 * PAULIS.Z, [PAULIS.X], [1.0]; dissipation_operators = [L])
+    ρ0 = ComplexF64[1.0 0.0; 0.0 0.0]
+    ρg = ComplexF64[0.0 0.0; 0.0 1.0]
+
+    qtraj_d = DensityTrajectory(osys, pulse, ρ0, ρg)
+    Rollouts._update_system!(qtraj_d, osys2)
+    @test qtraj_d.system === osys2
+
+    qtraj_md = MultiDensityTrajectory(osys, pulse, [ρ0, ρg], [ρg, ρ0])
+    Rollouts._update_system!(qtraj_md, osys2)
+    @test qtraj_md.system === osys2
+
+    # SamplingTrajectory delegates to its base trajectory only — the systems
+    # array (the sampled variations) is deliberately untouched.
+    base = UnitaryTrajectory(sys, pulse, GATES[:X])
+    sampling = SamplingTrajectory(base, [sys, sys2])
+    Rollouts._update_system!(sampling, sys2)
+    @test sampling.base_trajectory.system === sys2
+    @test sampling.systems == [sys, sys2]
 end

--- a/src/visualizations/quantum_objects/weyl_trajectory.jl
+++ b/src/visualizations/quantum_objects/weyl_trajectory.jl
@@ -97,3 +97,75 @@ function plot_weyl_trajectory(traj::NamedTrajectory, output_mp4 = "weyl_trajecto
 
     return fig
 end
+
+# ============================================================================ #
+# Tests
+# ============================================================================ #
+
+@testitem "c1c2c3 maps canonical two-qubit gates to their Weyl chamber classes" begin
+    using Piccolo
+    using LinearAlgebra
+
+    c1c2c3 = Piccolo.Visualizations.QuantumObjectPlots.c1c2c3
+
+    I4 = Matrix{ComplexF64}(I, 4, 4)
+    SWAP = ComplexF64[1 0 0 0; 0 0 1 0; 0 1 0 0; 0 0 0 1]
+    CNOT = ComplexF64[1 0 0 0; 0 1 0 0; 0 0 0 1; 0 0 1 0]
+    iSWAP = ComplexF64[1 0 0 0; 0 0 im 0; 0 im 0 0; 0 0 0 1]
+    CZ = ComplexF64[1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 -1]
+
+    # Corners of the Weyl chamber.
+    @test collect(c1c2c3(I4)) ≈ [0.0, 0.0, 0.0] atol = 1e-6    # identity: O
+    @test collect(c1c2c3(SWAP)) ≈ [0.5, 0.5, 0.5] atol = 1e-6  # SWAP: A3
+    @test collect(c1c2c3(iSWAP)) ≈ [0.5, 0.5, 0.0] atol = 1e-6 # iSWAP: A1
+    @test collect(c1c2c3(CNOT)) ≈ [0.5, 0.0, 0.0] atol = 1e-6  # CNOT: A2
+    @test collect(c1c2c3(CZ)) ≈ [0.5, 0.0, 0.0] atol = 1e-6    # CZ is locally equivalent to CNOT
+
+    # A product of single-qubit gates is locally equivalent to the identity.
+    @test collect(c1c2c3(kron(PAULIS[:X], PAULIS[:X]))) ≈ [0.0, 0.0, 0.0] atol = 1e-6
+
+    # Local gates conjugating CNOT leave the class invariant.
+    L = kron(PAULIS[:X], PAULIS[:Y])
+    R = kron(PAULIS[:Z], PAULIS[:X])
+    @test collect(c1c2c3(L * CNOT * R)) ≈ collect(c1c2c3(CNOT)) atol = 1e-6
+
+    # The global phase is divided out via the det normalization.
+    @test collect(c1c2c3(exp(im * π / 7) * CNOT)) ≈ collect(c1c2c3(CNOT)) atol = 1e-6
+
+    # Only 4×4 matrices are accepted.
+    @test_throws DimensionMismatch c1c2c3(Matrix{ComplexF64}(I, 2, 2))
+    @test_throws DimensionMismatch c1c2c3(Matrix{ComplexF64}(I, 8, 8))
+end
+
+@testitem "plot_weyl_trajectory renders headlessly and records an mp4" begin
+    using Piccolo
+    using CairoMakie
+    using LinearAlgebra
+
+    # A short trajectory: identity → CNOT family → SWAP.
+    N = 5
+    I4 = Matrix{ComplexF64}(I, 4, 4)
+    SWAP = ComplexF64[1 0 0 0; 0 0 1 0; 0 1 0 0; 0 0 0 1]
+    CNOT = ComplexF64[1 0 0 0; 0 1 0 0; 0 0 0 1; 0 0 1 0]
+    Us = [I4, exp(-im * 0.2 * CNOT), exp(-im * 0.4 * CNOT), exp(-im * 0.7 * SWAP), SWAP]
+
+    traj = NamedTrajectory(
+        (Ũ⃗ = hcat(operator_to_iso_vec.(Us)...), u = zeros(1, N), Δt = fill(0.1, N));
+        controls = :u,
+        timestep = :Δt,
+    )
+
+    # Explicit output path.
+    out = tempname() * ".mp4"
+    fig = plot_weyl_trajectory(traj, out)
+    @test fig isa Figure
+    @test isfile(out)
+    @test filesize(out) > 0
+    rm(out; force = true)
+
+    # Default filename lands in the working directory.
+    fig2 = plot_weyl_trajectory(traj)
+    @test fig2 isa Figure
+    @test isfile("weyl_trajectory.mp4")
+    rm("weyl_trajectory.mp4"; force = true)
+end


### PR DESCRIPTION
Part of the coverage campaign (#294; baseline 85.45% → target 100%).

**weyl_trajectory.jl: 0% → ~95%+.** c1c2c3 canonical classes for the known two-qubit gates (identity→O, SWAP→A3, iSWAP→A1, CNOT/CZ→A2), local-conjugation + global-phase invariance, DimensionMismatch throws, and the headless end-to-end plot incl. mp4 recording on both argument forms.

**rollouts_extensions.jl: 66.6% → ~97%.** All 22 unexercised method bodies: rollout!/rollout variants (pulse, same-pulse/tol) for Ket/MultiKet/Density/MultiDensity — MultiDensity had zero coverage anywhere — the fidelity phases warn-and-ignore branches (both goal types), coherent MultiKet phased fidelity with an analytic $F=\cos^2(\theta/2)$ assertion, and all six `_update_system!` methods incl. the SamplingTrajectory delegation contract.

**Found (not fixed here):** `rollout!(qtraj; algorithm=Tsit5())` crashes on a MagnusAdapt4-constructed trajectory — the solution-field reassignment can't cross algorithm families (a MethodError after the ODE solve completes); both rollout! docstrings advertise exactly this recipe. Filed separately.