### PR TITLE
test(coverage): specs parse+materialize and drives to 100%; spline 69%→93.5% [cluster B]

### DIFF
--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -1845,6 +1845,19 @@ end
     ) isa QuantumControlProblem
     @test SplinePulseProblem(uq_lin2, N; piccolo_options = opts) isa QuantumControlProblem
 
+    # same printlns on the MultiKetTrajectory method
+    ψ0, ψ1 = ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]
+    mk_cub2 = MultiKetTrajectory(sys, cub2, [ψ0, ψ1], [ψ1, ψ0])
+    mk_lin2 = MultiKetTrajectory(sys, lin2, [ψ0, ψ1], [ψ1, ψ0])
+    @test SplinePulseProblem(
+        mk_cub2,
+        N;
+        du_bound = 4.0,
+        integrator_type = :pwc,
+        piccolo_options = opts,
+    ) isa QuantumControlProblem
+    @test SplinePulseProblem(mk_lin2, N; piccolo_options = opts) isa QuantumControlProblem
+
     # single KetTrajectory free-phase: subsystem_levels gate + φ globals +
     # KetFreePhaseInfidelityObjective
     sys1 = QuantumSystem(0.01 * σz, [σx], [1.0])

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -1728,3 +1728,282 @@ end
     extra_contribution = objective_value(extra_reg, qcp_extra.prob.trajectory)
     @test J_extra ≈ J_baseline + extra_contribution
 end
+
+@testitem "SplinePulseProblem #275 guards: cubic defaults, explicit integrator paths" begin
+    using Piccolo
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    T, N = 10.0, 11
+    times = collect(range(0.0, T, length = N))
+    sys = QuantumSystem(0.01 * σz, [σx], [1.0])
+
+    lin = LinearSplinePulse(0.1 * randn(1, N), times)
+    cub = CubicSplinePulse(0.1 * randn(1, N), zeros(1, N), times)
+    U_goal = σx
+    uq_lin = UnitaryTrajectory(sys, lin, U_goal)
+    uq_cub = UnitaryTrajectory(sys, cub, U_goal)
+
+    # CubicSplinePulse + no integrator declared: ERROR (issue #275 — the default
+    # PWC backend would silently drop :du and optimize a different waveform).
+    err = try
+        SplinePulseProblem(uq_cub, N)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("CubicSplinePulse defaults are not allowed", err.msg)
+    @test occursin("integrator_type = :pwc", err.msg)
+
+    # global_names without an integrator is an error on both trajectory methods
+    err = try
+        SplinePulseProblem(uq_lin, N; global_names = [:δ])
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("global_names requires a custom integrator", err.msg)
+
+    ψ0, ψ1 = ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]
+    mk = MultiKetTrajectory(sys, lin, [ψ0, ψ1], [ψ1, ψ0])
+    err = try
+        SplinePulseProblem(mk, N; global_names = [:δ])
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("global_names requires a custom integrator", err.msg)
+
+    # explicit single-integrator kwarg: fine for a linear spline (warns on the
+    # PWC default elsewhere), H1 error for cubic + BilinearIntegrator
+    integ = BilinearIntegrator(uq_lin, N)
+    qcp = SplinePulseProblem(uq_lin, N; integrator = integ)
+    @test qcp isa QuantumControlProblem
+
+    err = try
+        SplinePulseProblem(uq_cub, N; integrator = BilinearIntegrator(uq_cub, N))
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("H1", err.msg)
+
+    # explicit vector-of-integrators kwarg: same contract per element
+    qcp_vec = SplinePulseProblem(uq_lin, N; integrator = [integ])
+    @test qcp_vec isa QuantumControlProblem
+
+    err = try
+        SplinePulseProblem(uq_cub, N; integrator = [BilinearIntegrator(uq_cub, N)])
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("H1", err.msg)
+end
+
+@testitem "SplinePulseProblem du_bounds vectors, verbose details, KetTrajectory free_phase" begin
+    using Piccolo
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    T, N = 10.0, 11
+    times = collect(range(0.0, T, length = N))
+    # two drives so per-drive du_bounds differ from the scalar fill
+    sys = QuantumSystem(0.01 * σz, [σx, σx], [1.0, 1.0])
+    U_goal = σx
+
+    lin2 = LinearSplinePulse(0.1 * randn(2, N), times)
+    cub2 = CubicSplinePulse(0.1 * randn(2, N), zeros(2, N), times)
+    uq_lin2 = UnitaryTrajectory(sys, lin2, U_goal)
+    uq_cub2 = UnitaryTrajectory(sys, cub2, U_goal)
+
+    # per-drive du_bounds: LinearSplinePulse derivative-add path
+    qcp = SplinePulseProblem(uq_lin2, N; du_bounds = [5.0, 2.0])
+    lo, hi = get_trajectory(qcp).bounds[:du]
+    @test lo ≈ [-5.0, -2.0]
+    @test hi ≈ [5.0, 2.0]
+
+    # per-drive du_bounds: CubicSplinePulse update_bound! path
+    qcp2 = SplinePulseProblem(uq_cub2, N; du_bounds = [5.0, 2.0], integrator_type = :pwc)
+    lo2, hi2 = get_trajectory(qcp2).bounds[:du]
+    @test lo2 ≈ [-5.0, -2.0]
+    @test hi2 ≈ [5.0, 2.0]
+
+    # detailed display exercises the du-bounds and DerivativeIntegrator printlns
+    opts = PiccoloOptions(; display = :detailed)
+    @test SplinePulseProblem(
+        uq_cub2,
+        N;
+        du_bound = 4.0,
+        integrator_type = :pwc,
+        piccolo_options = opts,
+    ) isa QuantumControlProblem
+    @test SplinePulseProblem(uq_lin2, N; piccolo_options = opts) isa QuantumControlProblem
+
+    # single KetTrajectory free-phase: subsystem_levels gate + φ globals +
+    # KetFreePhaseInfidelityObjective
+    sys1 = QuantumSystem(0.01 * σz, [σx], [1.0])
+    lin1 = LinearSplinePulse(0.1 * randn(1, N), times)
+    ψ0, ψ1 = ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]
+    kq = KetTrajectory(sys1, lin1, ψ0, ψ1)
+    qcp3 = SplinePulseProblem(kq, N; free_phase = true, subsystem_levels = [2])
+    @test qcp3 isa QuantumControlProblem
+    @test haskey(get_trajectory(qcp3).global_components, :φ_1)
+
+    err = try
+        SplinePulseProblem(kq, N; free_phase = true)
+        nothing
+    catch e
+        e
+    end
+    @test err isa AssertionError
+end
+
+@testitem "SplinePulseProblem global_params system data and spline_interior_bound_constraints" begin
+    using Piccolo
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    T, N = 10.0, 11
+    times = collect(range(0.0, T, length = N))
+    U_goal = σx
+    ψ0, ψ1 = ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]
+
+    # a system carrying global_params seeds global_data on BOTH trajectory
+    # methods (the φ free-phase globals merge on top of it when asked for).
+    sysg = QuantumSystem(0.01 * σz, [σx], [1.0]; global_params = (δ = 0.2,))
+    lin = LinearSplinePulse(0.1 * randn(1, N), times)
+
+    uq = UnitaryTrajectory(sysg, lin, U_goal)
+    qcp = SplinePulseProblem(uq, N)
+    @test haskey(get_trajectory(qcp).global_components, :δ)
+
+    mk = MultiKetTrajectory(sysg, lin, [ψ0, ψ1], [ψ1, ψ0])
+    qcp2 = SplinePulseProblem(mk, N)
+    @test haskey(get_trajectory(qcp2).global_components, :δ)
+
+    sys1 = QuantumSystem(0.01 * σz, [σx], [1.0])
+    cub = CubicSplinePulse(0.1 * randn(1, N), zeros(1, N), times)
+    lin1 = LinearSplinePulse(0.1 * randn(1, N), times)
+
+    # spline_interior_bound_constraints without Piccolissimo loaded: warns and
+    # constructs (the Piccolissimo-present side needs the package; this env
+    # covers the fallback side only).
+    @test_logs (:warn, r"requires Piccolissimo") match_mode = :any SplinePulseProblem(
+        UnitaryTrajectory(sys1, cub, U_goal),
+        N;
+        integrator_type = :pwc,
+        spline_interior_bound_constraints = true,
+    )
+
+    # LinearSplinePulse: knot bounds suffice; the kwarg warns and is inert
+    @test_logs (:warn, r"only for CubicSplinePulse") match_mode = :any SplinePulseProblem(
+        UnitaryTrajectory(sys1, lin1, U_goal),
+        N;
+        spline_interior_bound_constraints = true,
+    )
+
+    # multi-ket method: both warnings, cubic via the acknowledged :pwc backend
+    mk_cub = MultiKetTrajectory(sys1, cub, [ψ0, ψ1], [ψ1, ψ0])
+    @test_logs (:warn, r"requires Piccolissimo") match_mode = :any SplinePulseProblem(
+        mk_cub,
+        N;
+        integrator_type = :pwc,
+        spline_interior_bound_constraints = true,
+    )
+    mk_lin = MultiKetTrajectory(sys1, lin1, [ψ0, ψ1], [ψ1, ψ0])
+    @test_logs (:warn, r"only for CubicSplinePulse") match_mode = :any SplinePulseProblem(
+        mk_lin,
+        N;
+        spline_interior_bound_constraints = true,
+    )
+end
+
+@testitem "SplinePulseProblem MultiKet cubic guards, du bounds, explicit integrators" begin
+    using Piccolo
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    T, N = 10.0, 11
+    times = collect(range(0.0, T, length = N))
+    sys = QuantumSystem(0.01 * σz, [σx], [1.0])
+    ψ0, ψ1 = ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]
+
+    lin = LinearSplinePulse(0.1 * randn(1, N), times)
+    cub = CubicSplinePulse(0.1 * randn(1, N), zeros(1, N), times)
+    mk_lin = MultiKetTrajectory(sys, lin, [ψ0, ψ1], [ψ1, ψ0])
+    mk_cub = MultiKetTrajectory(sys, cub, [ψ0, ψ1], [ψ1, ψ0])
+
+    # cubic + no integrator_type on the multi-ket method: same #275 error
+    err = try
+        SplinePulseProblem(mk_cub, N)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("CubicSplinePulse defaults are not allowed", err.msg)
+
+    # cubic + acknowledged :pwc backend: warns, constructs
+    @test_logs (:warn, r"PWC backend") match_mode = :any SplinePulseProblem(
+        mk_cub,
+        N;
+        integrator_type = :pwc,
+    )
+
+    # scalar du_bound: linear add-derivatives path and cubic update_bound! path
+    qcp = SplinePulseProblem(mk_lin, N; du_bound = 5.0)
+    lo, hi = get_trajectory(qcp).bounds[:du]
+    @test lo ≈ [-5.0] && hi ≈ [5.0]
+
+    qcp2 = SplinePulseProblem(mk_cub, N; du_bound = 5.0, integrator_type = :pwc)
+    lo2, hi2 = get_trajectory(qcp2).bounds[:du]
+    @test lo2 ≈ [-5.0] && hi2 ≈ [5.0]
+
+    # per-drive du_bounds vector on the multi-ket linear path
+    sys2 = QuantumSystem(0.01 * σz, [σx, σx], [1.0, 1.0])
+    lin2 = LinearSplinePulse(0.1 * randn(2, N), times)
+    mk_lin2 = MultiKetTrajectory(sys2, lin2, [ψ0, ψ1], [ψ1, ψ0])
+    qcp3 = SplinePulseProblem(mk_lin2, N; du_bounds = [5.0, 2.0])
+    lo3, hi3 = get_trajectory(qcp3).bounds[:du]
+    @test lo3 ≈ [-5.0, -2.0] && hi3 ≈ [5.0, 2.0]
+
+    # single-integrator kwarg branch: linear + a single integrator constructs
+    # (the vector-returning BilinearIntegrator(multiket, N) takes the vector
+    # branch; the single branch is the parallel-integrator contract).
+    uq_lin = UnitaryTrajectory(sys, lin, σx)
+    qcp4 = SplinePulseProblem(mk_lin, N; integrator = BilinearIntegrator(uq_lin, N))
+    @test qcp4 isa QuantumControlProblem
+
+    # cubic + a single BilinearIntegrator: the H1 guard fires before anything
+    # is built
+    uq_cub = UnitaryTrajectory(sys, cub, σx)
+    err = try
+        SplinePulseProblem(mk_cub, N; integrator = BilinearIntegrator(uq_cub, N))
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("H1", err.msg)
+
+    # 2-state ensemble: BilinearIntegrator returns a VECTOR — the vector branch
+    integs = BilinearIntegrator(mk_lin, N)
+    @test integs isa AbstractVector
+    qcp5 = SplinePulseProblem(mk_lin, N; integrator = integs)
+    @test qcp5 isa QuantumControlProblem
+
+    err = try
+        SplinePulseProblem(mk_cub, N; integrator = BilinearIntegrator(mk_cub, N))
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("H1", err.msg)
+end

--- a/src/quantum/systems/drives.jl
+++ b/src/quantum/systems/drives.jl
@@ -1110,6 +1110,16 @@ end
     for p in (i, j), q in (i, j)
         @test drive_coeff_hess(baked, u, p, q) ≈ drive_coeff_hess(trilinear, u, p, q)
     end
+
+    # The trilinear Hessian's g-cross terms (the branches the (i,j) block never
+    # touches): ∂²(u_i u_j u_g)/∂u_p∂u_q picks up u of the third index. The
+    # BAKED form has no such terms by design — baking removes the gauge
+    # direction — so assert the trilinear closure itself, against AD.
+    @test drive_coeff_hess(trilinear, u, i, g) ≈ u[j]
+    @test drive_coeff_hess(trilinear, u, g, i) ≈ u[j]
+    @test drive_coeff_hess(trilinear, u, j, g) ≈ u[i]
+    @test drive_coeff_hess(trilinear, u, g, j) ≈ u[i]
+    validate_drive_hessian(trilinear, 5)
 end
 
 @testitem "coupling_drive: AD cross-check + QuantumSystem integration" begin
@@ -1132,4 +1142,69 @@ end
     sys = QuantumSystem(zeros(ComplexF64, 2, 2), drives, [(-1.0, 1.0), (-1.0, 1.0)])
     u = [0.3, -0.8]
     @test sys.H(u, 0.0) ≈ 0.3 * σz + 0.5 * 0.3 * (-0.8) * H
+end
+
+# Minimal non-matrix Hamiltonian: exercises the generic NonlinearDrive
+# constructors (H stored as-is) and the _ensure_matrix fallbacks through the
+# generic drive_matrix / drive_dim / G methods.
+@testitem "drives: generic (non-matrix) Hamiltonians, ModulatedDrive Hessian, has_modulation" begin
+    using Piccolo
+    using SparseArrays
+    using LinearAlgebra
+
+    struct WrapOp
+        M::Matrix{ComplexF64}
+    end
+    Base.Matrix(w::WrapOp) = w.M
+
+    struct WrappedDrive <: AbstractDrive
+        H::WrapOp
+    end
+
+    H = sparse(ComplexF64[0 1; 1 0])
+
+    # ── generic NonlinearDrive constructors: H is not an AbstractMatrix ──
+    w = WrapOp(ComplexF64[1 0; 0 -1])
+
+    # 2-arg (auto Jacobian + Hessian via ForwardDiff)
+    d1 = NonlinearDrive(w, u -> u[1]^2)
+    @test d1.H === w                       # stored as-is, not sparsified
+    @test drive_coeff(d1, [3.0]) == 9.0
+    @test drive_coeff_jac(d1, [3.0], 1) ≈ 6.0
+    @test drive_coeff_hess(d1, [3.0], 1, 1) ≈ 2.0
+
+    # 3-arg (explicit Jacobian; Hessian still auto-generated)
+    d2 = NonlinearDrive(w, u -> u[1]^2, (u, j) -> j == 1 ? 2u[1] : 0.0)
+    @test d2.H === w
+    @test drive_coeff_jac(d2, [3.0], 1) ≈ 6.0
+    @test drive_coeff_hess(d2, [3.0], 1, 1) ≈ 2.0
+
+    # auto-generated derivatives agree with AD for the generic constructors too
+    validate_drive_jacobian(d1, 1)
+    validate_drive_hessian(d1, 1)
+
+    # ── generic drive_matrix / drive_dim / _ensure_matrix via a custom subtype ──
+    d = WrappedDrive(WrapOp(ComplexF64[0 1; 1 0]))
+    @test drive_matrix(d) == ComplexF64[0 1; 1 0]      # Base.Matrix fallback
+    @test drive_dim(d) == 2
+    @test Piccolo.Isomorphisms.G(d) == Piccolo.Isomorphisms.G(ComplexF64[0 1; 1 0])
+
+    # ── ModulatedDrive Hessian: base Hessian scaled by the modulation at t=0 ──
+    nd = NonlinearDrive(H, u -> u[1]^2 + u[2]^2)
+    md = ModulatedDrive(nd, t -> 2 + cos(3t))
+    u = [3.0, 4.0, 0.0]
+    @test drive_coeff_hess(md, u, 1, 1) ≈ 2.0 * (2 + cos(0.0))
+    @test drive_coeff_hess(md, u, 1, 2) ≈ 0.0
+    # wrapping a linear drive: zero base Hessian stays zero
+    ld = LinearDrive(H, 2)
+    md_l = ModulatedDrive(ld, t -> 2 + cos(3t))
+    @test drive_coeff_hess(md_l, u, 1, 1) == 0.0
+    @test drive_coeff_hess(md_l, u, 2, 2) == 0.0
+
+    # ── has_modulation across the drive types ──
+    @test !has_modulation(DriftTerm(H))                    # identity modulation
+    @test has_modulation(DriftTerm(H, t -> cos(2t)))
+    @test has_modulation(md_l)                             # ModulatedDrive always
+    @test !has_modulation(ld)
+    @test !has_modulation(nd)
 end

--- a/src/specs/materialize.jl
+++ b/src/specs/materialize.jl
@@ -1142,6 +1142,49 @@ end
         e
     end
     @test e isa Specs.SpecValidationError
+
+    # _build_goal's CompositeQuantumSystem branch: the goal embeds into each
+    # subsystem's computational subspace (unreachable via registered spec
+    # templates — MultiTransmonSystem takes positional args, so the specs
+    # kwargs-only factory cannot build one).
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    sub1 = QuantumSystem(0.01 * σz, [σx], [1.0])
+    sub2 = QuantumSystem(0.02 * σz, [σx], [1.0])
+    comp = CompositeQuantumSystem(
+        0.01 * kron(σx, σx),
+        Matrix{ComplexF64}[],
+        [sub1, sub2],
+        [1.0, 1.0],
+    )
+    goal = Specs._build_goal(Specs.GoalSpec(; kind = :unitary, gate = :CZ), comp)
+    @test goal isa EmbeddedOperator
+
+    # _build_goal / _build_pulse_trajectory defensive throws for an unknown
+    # goal kind — validation's trajectory-compat check blocks these on the
+    # materialize path (every registered template rejects :banana), so they are
+    # exercised directly.
+    e = try
+        Specs._build_goal(Specs.GoalSpec(; kind = :banana), sub1)
+        nothing
+    catch e
+        e
+    end
+    @test e isa Specs.SpecValidationError
+
+    spec = Specs.ProblemSpec(;
+        system = Specs.SystemSpec(; kind = :template, template = :TransmonSystem),
+        goal = Specs.GoalSpec(; kind = :banana),
+        pulse = Specs.PulseSpec(; kind = :linear_spline, T = 10.0),
+        problem = Specs.TemplateBlock(; template = :SplinePulseProblem, N = 11),
+    )
+    e = try
+        Specs._build_pulse_trajectory(spec, sub1, nothing)
+        nothing
+    catch e
+        e
+    end
+    @test e isa Specs.SpecValidationError
 end
 
 @testitem "materialize: integrator registration fallbacks via injected registry entry" begin

--- a/src/specs/materialize.jl
+++ b/src/specs/materialize.jl
@@ -976,3 +976,493 @@ end
     @test "pulse" in paths
     @test "system.template" in paths
 end
+
+@testitem "materialize: raw system + SmoothPulseProblem + zero-order pulse" begin
+    using Piccolo, Piccolo.Specs
+
+    # kind = "raw": explicit H_drift/H_drives as nested [re, im] pairs, default
+    # and explicit drive_bounds, zero-order pulse on the SmoothPulseProblem path.
+    RAW_TOML = """
+    schema_version = 1
+    kind = "control"
+    [system]
+    kind = "raw"
+    H_drift = [[[0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.01, 0.0]]]
+    H_drives = [[[[0.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [0.0, 0.0]]]]
+    params = { drive_bounds = [0.5] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    [pulse]
+    kind = "zero_order"
+    T = 10.0
+    [problem]
+    template = "SmoothPulseProblem"
+    N = 11
+    """
+    qcp = Specs.materialize(Specs.parse_spec(RAW_TOML; format = :toml))
+    @test qcp isa QuantumControlProblem
+    @test get_system(qcp).H(zeros(1), 0.0) ≈ ComplexF64[0.0 0.0; 0.0 0.01]
+    @test get_system(qcp).n_drives == 1
+
+    # omitted params → drive_bounds defaults to fill(1.0, n_drives)
+    qcp2 = Specs.materialize(
+        Specs.parse_spec(
+            replace(RAW_TOML, "params = { drive_bounds = [0.5] }\n" => "");
+            format = :toml,
+        ),
+    )
+    @test qcp2 isa QuantumControlProblem
+
+    # kind = "composite" is deferred — a structured validation error, never a crash
+    e = try
+        Specs.materialize(
+            Specs.parse_spec(
+                replace(RAW_TOML, "kind = \"raw\"" => "kind = \"composite\"");
+                format = :toml,
+            ),
+        )
+        nothing
+    catch e
+        e
+    end
+    @test e isa Specs.SpecValidationError
+    @test "system.kind" in [x.path for x in e.errors]
+end
+
+@testitem "materialize: ket goals, subspace goals, random pulse init" begin
+    using Piccolo, Piccolo.Specs
+
+    KET_TOML = """
+    schema_version = 1
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "ket"
+    target = "[0.0, 1.0, 0.0]"
+    [pulse]
+    kind = "linear_spline"
+    T = 10.0
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+
+    # default initial state (first basis vector), parsed target ket
+    qcp = Specs.materialize(Specs.parse_spec(KET_TOML; format = :toml))
+    @test qcp.qtraj isa KetTrajectory
+    @test qcp.qtraj.initial ≈ [1.0, 0.0, 0.0]
+    @test qcp.qtraj.goal ≈ [0.0, 1.0, 0.0]
+
+    # explicit initial: also a Julia-parseable complex vector
+    toml = replace(
+        KET_TOML,
+        "target = \"[0.0, 1.0, 0.0]\"" => "target = \"[0.0, 1.0, 0.0]\"\ninitial = \"[0.5, 0.5, 0.0]\"",
+    )
+    qcp2 = Specs.materialize(Specs.parse_spec(toml; format = :toml))
+    @test qcp2.qtraj.initial ≈ [0.5, 0.5, 0.0]
+
+    # ket goal without a target: structured error naming goal.target
+    e = try
+        Specs.materialize(
+            Specs.parse_spec(
+                replace(KET_TOML, "target = \"[0.0, 1.0, 0.0]\"" => "");
+                format = :toml,
+            ),
+        )
+        nothing
+    catch e
+        e
+    end
+    @test e isa Specs.SpecValidationError
+    @test "goal.target" in [x.path for x in e.errors]
+
+    # unitary goal with a subspace: EmbeddedOperator on the computational subspace
+    SUBSPACE_TOML = """
+    schema_version = 1
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    subspace = [[1, 2]]
+    [pulse]
+    kind = "linear_spline"
+    T = 10.0
+    init = "random"
+    seed = 42
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+    qcp3 = Specs.materialize(Specs.parse_spec(SUBSPACE_TOML; format = :toml))
+    @test qcp3.qtraj.goal isa EmbeddedOperator
+    @test qcp3.qtraj.goal.subspace == [1, 2]
+
+    # init = "random" seeds a deterministic, nonzero control guess
+    @test any(!=(0.0), get_trajectory(qcp3).u)
+    qcp3_again = Specs.materialize(Specs.parse_spec(SUBSPACE_TOML; format = :toml))
+    @test get_trajectory(qcp3_again).u == get_trajectory(qcp3).u  # same seed ⇒ same guess
+end
+
+@testitem "materialize: _concretize, _coerce_global_bounds, composite _build_system" begin
+    using Piccolo, Piccolo.Specs
+
+    # _concretize narrows boxed TOML/JSON vectors to concrete element types,
+    # leaving non-numeric and empty vectors untouched.
+    @test Specs._concretize([1, 2, 3]) == [1, 2, 3]
+    @test Specs._concretize([1, 2, 3]) isa Vector{Int}
+    @test Specs._concretize([0.02, 0.02]) isa Vector{Float64}
+    @test Specs._concretize(["a", "b"]) == ["a", "b"]
+    @test Specs._concretize([]) == []
+    @test Specs._concretize(3.0) == 3.0
+    @test Specs._concretize([1, 2.5]) == [1, 2.5]        # mixed → untouched
+    @test Specs._concretize_params(Dict(:b => [1, 2]))[:b] isa Vector{Int}
+
+    # _coerce_global_bounds: vector / scalar / tuple value forms
+    out = Specs._coerce_global_bounds(
+        Dict(:vec => [0.1, 0.9], :scl => 0.5, :tup => (0.2, 0.8)),
+    )
+    @test out[:vec] == (0.1, 0.9)
+    @test out[:scl] == 0.5
+    @test out[:tup] == (0.2, 0.8)
+
+    # :composite reaches _build_system only via a direct call (validation blocks
+    # it first on the materialize path) — the defensive throw is still SpecValidationError.
+    e = try
+        Specs._build_system(Specs.SystemSpec(; kind = :composite))
+        nothing
+    catch e
+        e
+    end
+    @test e isa Specs.SpecValidationError
+end
+
+@testitem "materialize: integrator registration fallbacks via injected registry entry" begin
+    using Piccolo, Piccolo.Specs
+    using Piccolo: BilinearIntegrator
+
+    # `exponential`/`spline` integrators live in Piccolissimo; without it the
+    # registry only has the `bilinear` sentinel. Inject a stand-in entry to
+    # exercise the non-bilinear branches (_build_integrator, the free_phase
+    # gating pass, _sampling_integrator_factory, and the template integrator
+    # kwarg pass-through), then remove it — the registries are process-global
+    # and shared across test items on a worker (see registries.jl testitem).
+    Specs.register_integrator!(
+        :probe_integrator,
+        Specs.RegistryEntry(;
+            factory = (qtraj, N; alg = :probe) -> BilinearIntegrator(qtraj, N),
+        ),
+    )
+
+    try
+        BASE = """
+        schema_version = 1
+        kind = "control"
+        [system]
+        kind = "template"
+        template = "TransmonSystem"
+        params = { levels = 3, drive_bounds = [0.02, 0.02] }
+        [goal]
+        kind = "unitary"
+        gate = "X"
+        subspace = [[1, 2]]
+        [pulse]
+        kind = "linear_spline"
+        T = 10.0
+        [problem]
+        template = "SplinePulseProblem"
+        N = 11
+        [integrator]
+        kind = "probe_integrator"
+        """
+
+        # the declared integrator is built and passed to the template explicitly
+        qcp = Specs.materialize(Specs.parse_spec(BASE; format = :toml))
+        @test qcp isa QuantumControlProblem
+        @test any(i -> i isa BilinearIntegrator, qcp.prob.integrators)
+
+        # free_phase is gated on a non-bilinear integrator kind: with the
+        # injected entry it passes validation, and global_bounds coerce into the
+        # free-phase φ variable's bounds.
+        for (gb_form, expected) in (
+            ("global_bounds = { \"φ_1\" = [0.1, 0.9] }" => (0.1, 0.9)),
+            ("global_bounds = { \"φ_1\" = 0.5 }" => (-0.5, 0.5)),
+        )
+            toml = replace(BASE, "[problem]" => "[problem]\nfree_phase = true\n$gb_form")
+            qcp = Specs.materialize(Specs.parse_spec(toml; format = :toml))
+            @test haskey(get_trajectory(qcp).global_components, :φ_1)
+        end
+
+        # the sampling wrapper resolves the same declared integrator into a
+        # factory for SamplingProblem (bilinear → nothing is the other branch).
+        SAMPLING_TOML = """
+        schema_version = 1
+        kind = "control"
+        [system]
+        kind = "template"
+        template = "TransmonSystem"
+        params = { levels = 3, drive_bounds = [0.02, 0.02], "δ" = 0.2 }
+        [goal]
+        kind = "unitary"
+        gate = "X"
+        [pulse]
+        kind = "linear_spline"
+        T = 10.0
+        [problem]
+        template = "SplinePulseProblem"
+        N = 11
+        [integrator]
+        kind = "probe_integrator"
+        [[wrappers]]
+        kind = "sampling"
+        variants = [ { "δ" = 0.19 }, { "δ" = 0.21 } ]
+        """
+        s = Specs.materialize(Specs.parse_spec(SAMPLING_TOML; format = :toml))
+        @test length(Specs.get_variants(s)) == 2
+
+        # _sampling_integrator_factory: nothing for bilinear / absent kinds
+        bilinear_spec = Specs.parse_spec(
+            replace(SAMPLING_TOML, "kind = \"probe_integrator\"" => "kind = \"bilinear\"");
+            format = :toml,
+        )
+        @test Specs._sampling_integrator_factory(bilinear_spec) === nothing
+        no_int_spec = Specs.parse_spec(
+            replace(SAMPLING_TOML, "[integrator]\nkind = \"probe_integrator\"\n" => "");
+            format = :toml,
+        )
+        @test Specs._sampling_integrator_factory(no_int_spec) === nothing
+
+        # ket + free_phase on SmoothPulseProblem (compat ket_free_phase = false):
+        # reachable only with a non-bilinear integrator kind declared, and then
+        # still a structured validation error.
+        KET_SMOOTH_TOML = """
+        schema_version = 1
+        kind = "control"
+        [system]
+        kind = "template"
+        template = "TransmonSystem"
+        params = { levels = 3, drive_bounds = [0.02, 0.02] }
+        [goal]
+        kind = "ket"
+        target = "[0.0, 1.0, 0.0]"
+        [pulse]
+        kind = "zero_order"
+        T = 10.0
+        [problem]
+        template = "SmoothPulseProblem"
+        N = 11
+        free_phase = true
+        [integrator]
+        kind = "probe_integrator"
+        """
+        e = try
+            Specs.materialize(Specs.parse_spec(KET_SMOOTH_TOML; format = :toml))
+            nothing
+        catch e
+            e
+        end
+        @test e isa Specs.SpecValidationError
+        @test "problem.free_phase" in [x.path for x in e.errors]
+    finally
+        delete!(Specs.INTEGRATORS, :probe_integrator)
+    end
+end
+
+@testitem "materialize: objective term kinds build into the composed problem" begin
+    using Piccolo, Piccolo.Specs
+
+    _obj_terms(J) =
+        J isa DirectTrajOpt.CompositeObjective ? collect(J.objectives) :
+        AbstractObjective[J]
+
+    BASE = """
+    schema_version = 1
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    [pulse]
+    kind = "linear_spline"
+    T = 10.0
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+
+    # reg_u: an extra QuadraticRegularizer on the drive variable
+    qcp = Specs.materialize(
+        Specs.parse_spec(
+            BASE * "\n[[problem.objectives]]\nkind = \"reg_u\"\nweight = 0.1\n";
+            format = :toml,
+        ),
+    )
+    @test count(
+        o -> o isa DirectTrajOpt.QuadraticRegularizer && o.name == :u,
+        _obj_terms(qcp.prob.objective),
+    ) == 2
+
+    # reg_ddu: only valid on SmoothPulseProblem (the ddu-carrying template)
+    smooth = replace(
+        BASE,
+        "linear_spline" => "zero_order",
+        "SplinePulseProblem" => "SmoothPulseProblem",
+    )
+    qcp2 = Specs.materialize(
+        Specs.parse_spec(
+            smooth * "\n[[problem.objectives]]\nkind = \"reg_ddu\"\nweight = 0.1\n";
+            format = :toml,
+        ),
+    )
+    @test qcp2 isa QuantumControlProblem
+
+    # leakage: a LeakageObjective is a full-horizon (times 1:N) KnotPointObjective
+    # on the state variable — structurally distinct from the terminal-knot
+    # infidelity objective and from the QuadraticRegularizer terms.
+    qcp3 = Specs.materialize(
+        Specs.parse_spec(
+            BASE * "\n[[problem.objectives]]\nkind = \"leakage\"\nweight = 10.0\n";
+            format = :toml,
+        ),
+    )
+    leaky = filter(_obj_terms(qcp3.prob.objective)) do o
+        o isa DirectTrajOpt.KnotPointObjective &&
+            o.var_names == [state_name(qcp3.qtraj)] &&
+            o.times == 1:11
+    end
+    @test length(leaky) == 1
+
+    # sensitivity: a UnitarySensitivityObjective is a terminal-knot (times [N])
+    # KnotPointObjective — a second one beyond the built-in infidelity term.
+    qcp4 = Specs.materialize(
+        Specs.parse_spec(
+            BASE * "\n[[problem.objectives]]\nkind = \"sensitivity\"\nweight = 10.0\n";
+            format = :toml,
+        ),
+    )
+    terminal = count(
+        o ->
+            o isa DirectTrajOpt.KnotPointObjective &&
+            o.var_names == [state_name(qcp4.qtraj)] &&
+            o.times == [11],
+        _obj_terms(qcp4.prob.objective),
+    )
+    @test terminal == 2
+
+    # a REGISTERED but unsupported term kind is a structured materialize error,
+    # not a silent skip or a MethodError (inject one, then remove it).
+    Specs.register_objective_term!(
+        :probe_term,
+        Specs.RegistryEntry(; factory = Specs.ConstFactory(:probe_term)),
+    )
+    try
+        e = try
+            Specs.materialize(
+                Specs.parse_spec(
+                    BASE *
+                    "\n[[problem.objectives]]\nkind = \"probe_term\"\nweight = 1.0\n";
+                    format = :toml,
+                ),
+            )
+            nothing
+        catch e
+            e
+        end
+        @test e isa Specs.SpecValidationError
+        @test "problem.objectives" in [x.path for x in e.errors]
+    finally
+        delete!(Specs.OBJECTIVE_TERMS, :probe_term)
+    end
+end
+
+@testitem "materialize: validation branch matrix" begin
+    using Piccolo, Piccolo.Specs
+
+    BASE = """
+    schema_version = 1
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    [pulse]
+    kind = "linear_spline"
+    T = 10.0
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+
+    # (name, toml, expected error path)
+    cases = [
+        ("missing [problem] block", replace(BASE, r"\[problem\][^\0]*\z" => ""), "problem"),
+        (
+            "unknown template",
+            replace(BASE, "SplinePulseProblem" => "NoSuchTemplate"),
+            "problem.template",
+        ),
+        (
+            "unregistered integrator kind",
+            BASE * "\n[integrator]\nkind = \"exponential\"\n",
+            "integrator.kind",
+        ),
+        (
+            "unknown goal kind",
+            replace(BASE, "kind = \"unitary\"" => "kind = \"banana\""),
+            "goal.kind",
+        ),
+        (
+            "pulse kind incompatible",
+            replace(BASE, "linear_spline" => "banana_pulse"),
+            "pulse.kind",
+        ),
+        (
+            "unknown objective term kind",
+            BASE * "\n[[problem.objectives]]\nkind = \"banana\"\n",
+            "problem.objectives",
+        ),
+        (
+            "reg_ddu requires SmoothPulseProblem",
+            BASE * "\n[[problem.objectives]]\nkind = \"reg_ddu\"\n",
+            "problem.objectives",
+        ),
+        (
+            "time objective requires free_dt",
+            BASE * "\n[[problem.objectives]]\nkind = \"time\"\n",
+            "problem.free_dt",
+        ),
+        (
+            "calibration target not in global_names",
+            BASE * "\ncalibration_targets = [\"δ\"]\n",
+            "problem.calibration_targets",
+        ),
+        (
+            "unknown wrapper kind",
+            BASE * "\n[[wrappers]]\nkind = \"banana\"\n",
+            "wrappers[1]",
+        ),
+    ]
+    for (name, toml, path) in cases
+        e = try
+            Specs.materialize(Specs.parse_spec(toml; format = :toml))
+            nothing
+        catch e
+            e
+        end
+        @test e isa Specs.SpecValidationError
+        @test path in [x.path for x in e.errors]
+    end
+end

--- a/src/specs/parse.jl
+++ b/src/specs/parse.jl
@@ -588,6 +588,7 @@ end
         end
     paths(e) = Set(x.path for x in e.errors)
     msgs(e) = Set(x.msg for x in e.errors)
+    @test errs_of(BASE) === nothing  # the helper's success path
 
     # integer-valued floats coerce (TOML has no Int/Float distinction)
     spec = Specs.parse_spec(replace(BASE, "N = 11" => "N = 11.0"); format = :toml)
@@ -664,6 +665,7 @@ end
         end
     paths(e) = Set(x.path for x in e.errors)
     msgs(e) = Set(x.msg for x in e.errors)
+    @test errs_of(BASE) === nothing  # the helper's success path
 
     # free_dt: false (default) and [lo, hi] parse; true / bad ordering / bad shape error
     spec = Specs.parse_spec(replace(BASE, "N = 11" => "N = 11\nfree_dt = [0.05, 0.5]"))
@@ -737,6 +739,7 @@ end
         end
     paths(e) = Set(x.path for x in e.errors)
     msgs(e) = Set(x.msg for x in e.errors)
+    @test errs_of(BASE) === nothing  # the helper's success path
 
     # every block-typed field rejects a scalar with "expected a table" at its path
     nontable = [

--- a/src/specs/parse.jl
+++ b/src/specs/parse.jl
@@ -556,3 +556,265 @@ _parse_referee(raw, path, errs) =
     bad = toml * "\nnonsense_field = true\n"
     @test_throws Specs.SpecValidationError Specs.parse_spec(bad; format = :toml)
 end
+
+@testitem "parse: scalar coercion and required-field errors carry field paths" begin
+    using Piccolo.Specs
+
+    BASE = """
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    subsystem_levels = [3, 3]
+    [pulse]
+    kind = "cubic_spline"
+    T = 10.0
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+
+    # Collect the SpecValidationError a toml produces (nothing when it parses).
+    errs_of(toml; format = :toml) =
+        try
+            Specs.parse_spec(toml; format = format)
+            nothing
+        catch e
+            e isa Specs.SpecValidationError ? e : rethrow()
+        end
+    paths(e) = Set(x.path for x in e.errors)
+    msgs(e) = Set(x.msg for x in e.errors)
+
+    # integer-valued floats coerce (TOML has no Int/Float distinction)
+    spec = Specs.parse_spec(replace(BASE, "N = 11" => "N = 11.0"); format = :toml)
+    @test spec.problem.N == 11
+
+    # non-numeric integers / numbers / booleans are collected, not first-fatal
+    e = errs_of(replace(BASE, "N = 11" => "N = \"eleven\""))
+    @test "problem.N" in paths(e)
+    @test any(m -> occursin("expected an integer", m), msgs(e))
+    e = errs_of(replace(BASE, "N = 11" => "N = true"))
+    @test "problem.N" in paths(e)
+
+    e = errs_of(replace(BASE, "T = 10.0" => "T = \"fast\""))
+    @test "pulse.T" in paths(e)
+    @test any(m -> occursin("expected a number", m), msgs(e))
+
+    e = errs_of(replace(BASE, "N = 11" => "N = 11\nfree_phase = \"yes\""))
+    @test "problem.free_phase" in paths(e)
+    @test any(m -> occursin("expected a boolean", m), msgs(e))
+
+    # unknown top-level kind and unknown format
+    e = errs_of(replace(BASE, "kind = \"control\"" => "kind = \"banana\""))
+    @test "kind" in paths(e)
+    e = try
+        Specs.parse_spec(BASE; format = :yaml)
+        nothing
+    catch e
+        e
+    end
+    @test e isa Specs.SpecValidationError
+    @test "format" in paths(e)
+
+    # missing required blocks / fields, each with its dotted path
+    e = errs_of(replace(BASE, r"\[system\][^\0]*?\n\[goal\]" => "[goal]"))
+    @test "system" in paths(e)
+    e = errs_of(replace(BASE, "kind = \"unitary\"\ngate = \"X\"" => "gate = \"X\""))
+    @test "goal.kind" in paths(e)
+    e = errs_of(replace(BASE, "kind = \"cubic_spline\"" => ""))
+    @test "pulse.kind" in paths(e)
+    e = errs_of(replace(BASE, "T = 10.0" => ""))
+    @test "pulse.T" in paths(e)
+    e = errs_of(replace(BASE, "template = \"SplinePulseProblem\"" => ""))
+    @test "problem.template" in paths(e)
+    e = errs_of(replace(BASE, "N = 11" => ""))
+    @test "problem.N" in paths(e)
+end
+
+@testitem "parse: free_dt and objective/wrapper list-shape errors" begin
+    using Piccolo.Specs
+
+    BASE = """
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    [pulse]
+    kind = "cubic_spline"
+    T = 10.0
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+
+    errs_of(toml) =
+        try
+            Specs.parse_spec(toml; format = :toml)
+            nothing
+        catch e
+            e isa Specs.SpecValidationError ? e : rethrow()
+        end
+    paths(e) = Set(x.path for x in e.errors)
+    msgs(e) = Set(x.msg for x in e.errors)
+
+    # free_dt: false (default) and [lo, hi] parse; true / bad ordering / bad shape error
+    spec = Specs.parse_spec(replace(BASE, "N = 11" => "N = 11\nfree_dt = [0.05, 0.5]"))
+    @test spec.problem.free_dt isa Free
+    @test spec.problem.free_dt.lo == 0.05
+    @test spec.problem.free_dt.hi == 0.5
+
+    e = errs_of(replace(BASE, "N = 11" => "N = 11\nfree_dt = true"))
+    @test "problem.free_dt" in paths(e)
+    @test any(m -> occursin("not true", m), msgs(e))
+
+    e = errs_of(replace(BASE, "N = 11" => "N = 11\nfree_dt = [0.5, 0.1]"))
+    @test "problem.free_dt" in paths(e)
+    @test any(m -> occursin("0 < lo < hi", m), msgs(e))
+
+    for bad in ("[1, 2, 3]", "\"yes\"", "[0.1]")
+        e = errs_of(replace(BASE, "N = 11" => "N = 11\nfree_dt = $bad"))
+        @test "problem.free_dt" in paths(e)
+        @test any(m -> occursin("false or [lo, hi]", m), msgs(e))
+    end
+
+    # [[problem.objectives]] shape errors
+    e = errs_of(replace(BASE, "N = 11" => "N = 11\nobjectives = \"nope\""))
+    @test "problem.objectives" in paths(e)
+    @test any(m -> occursin("expected a list", m), msgs(e))
+
+    e = errs_of(replace(BASE, "N = 11" => "N = 11\nobjectives = [\"nope\"]"))
+    @test "problem.objectives[1]" in paths(e)
+
+    e = errs_of(replace(BASE, "N = 11" => "N = 11\n[[problem.objectives]]\nweight = 1.0"))
+    @test "problem.objectives[1].kind" in paths(e)
+
+    # wrappers shape errors (top-level keys must precede the first [table])
+    e = errs_of("wrappers = \"nope\"\n" * BASE)
+    @test "wrappers" in paths(e)
+    @test any(m -> occursin("expected a list of wrappers", m), msgs(e))
+
+    e = errs_of("wrappers = [\"nope\"]\n" * BASE)
+    @test "wrappers[1]" in paths(e)
+
+    e = errs_of("wrappers = [ {} ]\n" * BASE)
+    @test "wrappers[1].kind" in paths(e)
+end
+
+@testitem "parse: non-table blocks, optional blocks, and rollout-side errors" begin
+    using Piccolo.Specs
+
+    BASE = """
+    kind = "control"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    [goal]
+    kind = "unitary"
+    gate = "X"
+    [pulse]
+    kind = "cubic_spline"
+    T = 10.0
+    [problem]
+    template = "SplinePulseProblem"
+    N = 11
+    """
+
+    errs_of(toml; format = :toml) =
+        try
+            Specs.parse_spec(toml; format = format)
+            nothing
+        catch e
+            e isa Specs.SpecValidationError ? e : rethrow()
+        end
+    paths(e) = Set(x.path for x in e.errors)
+    msgs(e) = Set(x.msg for x in e.errors)
+
+    # every block-typed field rejects a scalar with "expected a table" at its path
+    nontable = [
+        (
+            "system",
+            "system = \"oops\"\n" *
+            replace(BASE, r"\[system\][^\0]*?\n\[goal\]" => "[goal]"),
+        ),
+        ("goal", "goal = 5\n" * replace(BASE, r"\[goal\][^\0]*?\n\[pulse\]" => "[pulse]")),
+        (
+            "pulse",
+            "pulse = \"oops\"\n" *
+            replace(BASE, r"\[pulse\][^\0]*?\n\[problem\]" => "[problem]"),
+        ),
+        ("problem", "problem = \"oops\"\n" * replace(BASE, r"\[problem\][^\0]*\z" => "")),
+        ("trajectory", "trajectory = \"oops\"\n" * BASE),
+        ("integrator", "integrator = \"oops\"\n" * BASE),
+        ("solver", "solver = \"oops\"\n" * BASE),
+        ("warm_start", "warm_start = \"oops\"\n" * BASE),
+    ]
+    for (name, toml) in nontable
+        e = errs_of(toml)
+        @test name in paths(e)
+        @test any(m -> occursin("expected a table", m), msgs(e))
+    end
+
+    # optional blocks parse on the happy path
+    spec = Specs.parse_spec(BASE * "\n[trajectory]\nkind = \"unitary\"")
+    @test spec.trajectory isa TrajectorySpec
+    @test spec.trajectory.kind == :unitary
+
+    spec = Specs.parse_spec(
+        BASE * "\n[warm_start]\ncatalog_ref = \"transmon/x-v1\"\npulse_hash = \"abc123\"";
+    )
+    @test spec.warm_start isa WarmStartSpec
+    @test spec.warm_start.catalog_ref == "transmon/x-v1"
+    @test spec.warm_start.pulse_hash == "abc123"
+
+    # rollout kind: required fields and non-table [report]/[referee]
+    ROLLOUT = """
+    kind = "rollout"
+    input_pulse = "pulse.jld2"
+    rollout_kind = "unitary"
+    [system]
+    kind = "template"
+    template = "TransmonSystem"
+    params = { levels = 3, drive_bounds = [0.02, 0.02] }
+    """
+
+    e = errs_of("report = \"oops\"\n" * ROLLOUT)
+    @test "report" in paths(e)
+    e = errs_of("referee = \"oops\"\n" * ROLLOUT)
+    @test "referee" in paths(e)
+
+    e = errs_of(replace(ROLLOUT, "input_pulse = \"pulse.jld2\"\n" => ""))
+    @test "input_pulse" in paths(e)
+    e = errs_of(replace(ROLLOUT, "rollout_kind = \"unitary\"\n" => ""))
+    @test "rollout_kind" in paths(e)
+    e = errs_of("""
+    kind = "rollout"
+    input_pulse = "pulse.jld2"
+    rollout_kind = "unitary"
+    """)
+    @test "system" in paths(e)
+
+    # referee: every missing required field is collected
+    e = errs_of(ROLLOUT * "\n[referee]\nrun = \"r1\"")
+    @test "referee.solve_knots" in paths(e)
+    @test "referee.solve_integrator" in paths(e)
+    @test "referee.fidelity_reported" in paths(e)
+
+    # report happy path incl. nested goal
+    spec = Specs.parse_spec(
+        ROLLOUT *
+        "\n[report]\nfidelity = false\npopulations = true\n[report.goal]\nkind = \"unitary\"\ngate = \"X\"";
+    )
+    @test spec.report isa RolloutReportSpec
+    @test spec.report.fidelity == false
+    @test spec.report.populations == true
+    @test spec.report.goal isa GoalSpec
+end


### PR DESCRIPTION
Part of the coverage campaign (#294; baseline 85.45% → target 100%).

- **specs/parse.jl → 100%** — every coercion error, unknown kind/format, missing-field path, free_dt shape variant, rollout-side and referee errors.
- **specs/materialize.jl → 100%** — raw systems, ket goals, composite goals, integrator fallbacks via injected registry entries, all six objective-term kinds, the 10-case validation matrix.
- **systems/drives.jl → 100%** — ModulatedDrive Hessian, generic non-matrix-H NonlinearDrive with AD validation, custom AbstractDrive subtype through the generic paths, trilinear Hessian cross-terms.
- **spline_pulse_problem.jl 69.4% → 93.5%** — both methods' guard branches, du_bounds vectors, free-phase asserts, verbose printlns; the remainder is the Piccolissimo-conditional interior-bounds side (unreachable in this repo's env) and dead code filed separately.

**213 new tests, all passing; 572/572 across the touched + specs files locally.** Bugs found are filed separately (specs factory breakage ×2, dead code ×3).