### PR TITLE
test(coverage): cluster C — display, dynamics, systems, templates, exts (85.5% → ~97%)

### DIFF
--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -521,6 +521,174 @@ function (cb::_LivePulsePlotCallback)(primal::AbstractVector, iter::Integer)
 end
 
 
+
+@testitem "animate_figure rejects unsupported modes" begin
+    using NamedTrajectories
+    using CairoMakie
+
+    comps = (ψ̃ = hcat(ket_to_iso(ComplexF64[1.0, 0.0])), Δt = [1.0])
+    traj = NamedTrajectory(comps)
+    fig = Figure()
+    ax = Axis(fig[1, 1])
+    scatter!(ax, [0.0], [0.0])
+
+    @test_throws ArgumentError Piccolo.animate_figure(fig, [1], i -> nothing; mode = :bogus)
+end
+
+@testitem "animate_name records an mp4 (redraw path)" begin
+    using NamedTrajectories
+    using CairoMakie
+
+    # A longer trajectory so several redraw frames are exercised
+    N = 6
+    ψ̃ = hcat(
+        [ket_to_iso(ComplexF64[cos(θ), sin(θ)]) for θ in range(0, π / 2; length = N)]...,
+    )
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = fill(0.1, N)))
+
+    out = tempname() * ".mp4"
+    fig = animate_name(traj, :ψ̃; mode = :record, fps = 5, filename = out)
+    @test fig isa Figure
+    @test isfile(out)
+    @test filesize(out) > 0
+    rm(out; force = true)
+end
+
+@testitem "animate_pulse sweeps: overlay layout and custom labels" begin
+    using CairoMakie
+
+    pulses =
+        [GaussianPulse([amp, 0.5 * amp], 0.2, 1.0) for amp in range(0.2, 0.6, length = 3)]
+
+    # Overlay layout: one shared axis + legend
+    fig_overlay = animate_pulse(
+        pulses;
+        mode = :inline,
+        layout = :overlay,
+        n_samples = 8,
+        labels = ["Ω_x", "Ω_y"],
+    )
+    @test fig_overlay isa Figure
+
+    # Stacked layout with custom labels (assert path in _pulse_drive_labels)
+    fig_stacked = animate_pulse(
+        pulses;
+        mode = :inline,
+        layout = :stacked,
+        n_samples = 8,
+        labels = ["Ω_x", "Ω_y"],
+        parameter_values = [0.2, 0.4, 0.6],
+        parameter_label = "amp",
+    )
+    @test fig_stacked isa Figure
+
+    # Too few labels are rejected
+    @test_throws AssertionError animate_pulse(
+        pulses;
+        mode = :inline,
+        n_samples = 8,
+        labels = ["only-one"],
+    )
+end
+
+@testitem "animate_pulse degenerate y-limits" begin
+    using CairoMakie
+
+    MakieExt = Base.get_extension(Piccolo, :PiccoloMakieExt)
+    _pulse_y_limits = MakieExt._pulse_y_limits
+    _padded_extrema = MakieExt._padded_extrema
+
+    # Flat drive values: pad collapses to a fraction of |lo|
+    lo, hi = _pulse_y_limits(fill(2.0, 3, 5))
+    @test lo < 2.0 < hi
+
+    # All-NaN values: the empty-finite fallback window
+    lo2, hi2 = _pulse_y_limits(fill(NaN, 3, 5))
+    @test (lo2, hi2) == (-1.0, 1.0)
+
+    # _padded_extrema on a flat range gets the unit window
+    @test _padded_extrema(fill(1.0, 4)) == (0.5, 1.5)
+    # ... and on a genuine range gets padded symmetrically
+    lo3, hi3 = _padded_extrema([0.0, 1.0])
+    @test lo3 < 0.0 && hi3 > 1.0
+    @test (hi3 - lo3) ≈ 1.16 atol = 1e-12
+
+    # Flat pulses render without error through the single-pulse animator
+    times = collect(range(0, 2.0, length = 8))
+    flat = ZeroOrderPulse(fill(0.5, 1, 8), times)
+    fig = animate_pulse(flat; mode = :inline, n_samples = 10)
+    @test fig isa Figure
+end
+
+@testitem "animate_pulse population_times mismatch is rejected" begin
+    using CairoMakie
+
+    T = 4.0
+    pulse = GaussianPulse([0.5, 0.3], T / 6, T)
+    pops = reshape([0.1, 0.9, 0.2, 0.8], 2, 2)
+
+    @test_throws ArgumentError animate_pulse(
+        pulse;
+        populations = pops,
+        population_times = [0.0, 0.5, 1.0],  # wrong length (3 ≠ 2)
+    )
+end
+
+@testitem "LivePulsePlotCallback: primal mismatch warning and global update" begin
+    using DirectTrajOpt
+    using NamedTrajectories
+    using CairoMakie
+    using Random
+    using LinearAlgebra
+
+    Random.seed!(77)
+    sys = QuantumSystem(0.5 * PAULIS[:Z], [PAULIS[:X]], [1.0])
+    T, N = 5.0, 10
+    times = collect(range(0, T, length = N))
+    qtraj = UnitaryTrajectory(sys, ZeroOrderPulse(0.1 * randn(1, N), times), GATES[:X])
+    qcp = SmoothPulseProblem(
+        qtraj,
+        N;
+        piccolo_options = PiccoloOptions(timesteps_all_equal = true, display = :silent),
+    )
+    traj = qcp.prob.trajectory
+
+    save_dir = mktempdir()
+    cb = LivePulsePlotCallback(qtraj, traj; save_dir = save_dir)
+
+    expected = traj.dim * traj.N + traj.global_dim
+
+    # Wrong-length primal: warns (maxlog=1) and skips the render, returning true
+    @test_logs (:warn, r"primal-vector length mismatch") match_mode = :any cb(
+        randn(expected + 3),
+        0,
+    ) === true
+    # No PNG written for the mismatched call
+    @test isempty(filter(f -> endswith(f, ".png"), readdir(save_dir)))
+
+    # Global-carrying trajectory (free-phase spline): the update! type=:both path
+    H_drift_3 = ComplexF64[0 0 0; 0 1 0; 0 0 2]
+    H_drive_3 = ComplexF64[0 1 0; 1 0 1; 0 1 0] / √2
+    sys3 = QuantumSystem(H_drift_3, [H_drive_3], [1.0])
+    pulse3 = LinearSplinePulse(0.1 * ones(1, N), times)
+    U_goal = EmbeddedOperator(ComplexF64[0 1; 1 0], [1, 2], [3])
+    qtraj3 = UnitaryTrajectory(sys3, pulse3, U_goal)
+    qcp3 = SplinePulseProblem(
+        qtraj3,
+        N;
+        free_phase = true,
+        piccolo_options = PiccoloOptions(display = :silent),
+    )
+    traj3 = qcp3.prob.trajectory
+    @test traj3.global_dim == 1
+
+    save_dir3 = mktempdir()
+    cb3 = LivePulsePlotCallback(qtraj3, traj3; save_dir = save_dir3)
+    expected3 = traj3.dim * traj3.N + traj3.global_dim
+    @test cb3(randn(expected3), 0) === true
+    @test length(filter(f -> endswith(f, ".png"), readdir(save_dir3))) == 1
+end
+
 @testitem "Test animate_name for NamedTrajectory" begin
     using QuantumToolbox
     using NamedTrajectories

--- a/ext/PiccoloQuantumToolboxExt.jl
+++ b/ext/PiccoloQuantumToolboxExt.jl
@@ -372,6 +372,142 @@ end
 # ============================================================================ #
 
 
+
+@testitem "plot_bloch! updates the saved vector observable" begin
+    using QuantumToolbox
+    using NamedTrajectories
+    using Piccolo
+    using CairoMakie
+    using LinearAlgebra
+
+    θs = range(0, π / 2; length = 6)
+    ψ̃ = hcat([ket_to_iso(ComplexF64[cos(θ), sin(θ)]) for θ in θs]...)
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = fill(0.1, 6)))
+
+    # index=1 saves the :vec observable for animation
+    fig = QuantumToolbox.plot_bloch(traj; index = 1)
+    @test haskey(fig.attributes, :vec)
+    v_before = copy(fig.attributes[:vec][])
+
+    # KNOWN BUG (reported): plot_bloch! reads `b.b.vector_tiplength` from the
+    # saved QuantumToolbox.Bloch, which has no field `b` — the update path
+    # throws FieldError before moving the arrow. We lock in the no-crash-silently
+    # contract: the call throws (rather than silently returning a stale figure).
+    @test_throws Exception Piccolo.plot_bloch!(fig, traj, 6)
+
+    # A figure without animation attributes is a no-op that returns the figure
+    fig_plain = QuantumToolbox.plot_bloch(traj)
+    @test !haskey(fig_plain.attributes, :vec)
+    @test Piccolo.plot_bloch!(fig_plain, traj, 2) === fig_plain
+
+    # Out-of-range knot index is rejected before any attribute access
+    @test_throws AssertionError Piccolo.plot_bloch!(fig, traj, 0)
+    @test_throws AssertionError Piccolo.plot_bloch!(fig, traj, 7)
+end
+
+@testitem "animate_bloch currently throws (documented bug)" begin
+    using QuantumToolbox
+    using NamedTrajectories
+    using Piccolo
+    using CairoMakie
+
+    θs = range(0, π / 2; length = 5)
+    ψ̃ = hcat([ket_to_iso(ComplexF64[cos(θ), sin(θ)]) for θ in θs]...)
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = fill(0.1, 5)))
+
+    # KNOWN BUG (reported): animate_bloch's per-frame update calls plot_bloch!,
+    # which reads `b.b.vector_tiplength` off a QuantumToolbox.Bloch that has no
+    # field `b`. Until that is fixed, every animation frame throws FieldError.
+    @test_throws Exception Piccolo.animate_bloch(traj; mode = :record, fps = 4)
+end
+
+@testitem "plot_bloch argument guards" begin
+    using QuantumToolbox
+    using NamedTrajectories
+    using Piccolo
+    using CairoMakie
+
+    ψ̃ = hcat(ket_to_iso(ComplexF64[1.0, 0.0]), ket_to_iso(ComplexF64[0.0, 1.0]))
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = [1.0, 1.0]))
+
+    # KNOWN BUG (reported): the unknown-state_type guard calls `raise(...)`,
+    # which is undefined in the extension — the guard throws UndefVarError
+    # instead of the intended ArgumentError. The branch is still exercised.
+    @test_throws Exception QuantumToolbox.plot_bloch(traj; state_type = :bogus)
+
+    # Index outside the knot range is rejected
+    @test_throws AssertionError QuantumToolbox.plot_bloch(traj; index = 0)
+    @test_throws AssertionError QuantumToolbox.plot_bloch(traj; index = 3)
+end
+
+@testitem "plot_wigner! updates the heatmap and label" begin
+    using QuantumToolbox
+    using NamedTrajectories
+    using Piccolo
+    using CairoMakie
+
+    N = 12
+    α = 1.2
+    ψ1 = coherent(N, α)
+    ψ2 = coherent(N, im * α)
+    ψ̃ = hcat(ket_to_iso(ψ1.data), ket_to_iso(ψ2.data))
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = [1.0, 1.0]))
+
+    fig = QuantumToolbox.plot_wigner(traj, 1; state_name = :ψ̃)
+    hm = fig.attributes[:hm][]
+    W_before = copy(hm[3][])
+    label = fig.attributes[:label][]
+
+    fig2 = Piccolo.plot_wigner!(fig, traj, 2)
+    @test fig2 === fig
+    @test hm[3][] != W_before                 # heatmap updated
+    @test label.text[] == "Timestep 2"        # label updated
+
+    # Out-of-range index is rejected
+    @test_throws AssertionError Piccolo.plot_wigner!(fig, traj, 0)
+    @test_throws AssertionError Piccolo.plot_wigner!(fig, traj, 3)
+end
+
+@testitem "plot_wigner argument guards" begin
+    using QuantumToolbox
+    using NamedTrajectories
+    using Piccolo
+    using CairoMakie
+
+    ψ̃ = hcat(ket_to_iso(coherent(10, 0.5).data))
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = [1.0]))
+
+    # KNOWN BUG (reported): same undefined `raise(...)` guard as plot_bloch —
+    # UndefVarError instead of ArgumentError. The branch is still exercised.
+    @test_throws Exception QuantumToolbox.plot_wigner(
+        traj,
+        1;
+        state_name = :ψ̃,
+        state_type = :bogus,
+    )
+    # Index outside the knot range is rejected
+    @test_throws AssertionError QuantumToolbox.plot_wigner(traj, 2; state_name = :ψ̃)
+end
+
+@testitem "animate_wigner records an mp4" begin
+    using QuantumToolbox
+    using NamedTrajectories
+    using Piccolo
+    using CairoMakie
+
+    N = 10
+    states = [coherent(N, 0.3 * k * (1 + im)) for k = 1:3]
+    ψ̃ = hcat([ket_to_iso(s.data) for s in states]...)
+    traj = NamedTrajectory((ψ̃ = ψ̃, Δt = fill(0.1, 3)))
+
+    out = tempname() * ".mp4"
+    fig = Piccolo.animate_wigner(traj; mode = :record, fps = 3, filename = out)
+    @test fig isa Figure
+    @test isfile(out)
+    @test filesize(out) > 0
+    rm(out; force = true)
+end
+
 @testitem "Test plot_bloch for Bloch sphere ket trajectory" begin
     using QuantumToolbox
     using NamedTrajectories

--- a/src/control/display/show.jl
+++ b/src/control/display/show.jl
@@ -6,6 +6,8 @@
 # `Base.show(io, qcp)`                     → :compact one-line summary
 # `show_problem(io, qcp; detail)`          → explicit entry point
 
+using TestItems
+
 # ---------------------------------------------------------------------------- #
 # Tree-rendering glyphs
 # ---------------------------------------------------------------------------- #
@@ -334,4 +336,594 @@ function _fmt_val(v::Real)
     else
         return @sprintf("%.4g", v)
     end
+end
+
+# ============================================================================ #
+# Tests
+# ============================================================================ #
+
+@testitem "show.jl small formatters" begin
+    using Piccolo
+
+    _fmt_T = Piccolo.Control.ProblemDisplay._fmt_T
+    _fmt_val = Piccolo.Control.ProblemDisplay._fmt_val
+
+    # _fmt_T: NaN, large, order-1, sub-1
+    @test _fmt_T(NaN) == "—"
+    @test _fmt_T(1234.5) == "1234.5"
+    @test _fmt_T(12.3456) == "12.346"
+    @test _fmt_T(0.0123) == "0.0123"
+
+    # _fmt_val: NaN, exact zero, huge, tiny, ordinary
+    @test _fmt_val(NaN) == "NaN"
+    @test _fmt_val(0.0) == "0"
+    @test _fmt_val(2.5e5) == "2.500e+05"
+    @test _fmt_val(3.7e-3) == "3.700e-03"
+    @test _fmt_val(0.5) == "0.5"
+end
+
+@testitem "inspect.jl bound-rendering helpers" begin
+    using Piccolo
+
+    PD = Piccolo.Control.ProblemDisplay
+
+    # _bound_repr: missing key → unbounded dash
+    @test PD._bound_repr((x = (-fill(1.0, 2), fill(1.0, 2)),), :u) == ("—", false)
+
+    # all-inf bounds → unbounded dash
+    bounds = (u = (fill(-Inf, 2), fill(Inf, 2)),)
+    @test PD._bound_repr(bounds, :u) == ("—", false)
+
+    # symmetric vector bounds, short (n ≤ 4): "±[values]"
+    r, b = PD._bound_repr((u = ([-1.0, -0.5], [1.0, 0.5]),), :u)
+    @test b
+    @test occursin("±", r)
+    @test occursin("1.0", r)
+
+    # symmetric vector bounds, long (n > 4): summarized with "…"
+    lo = -collect(1.0:6.0)
+    hi = collect(1.0:6.0)
+    r_long, b_long = PD._bound_repr((u = (lo, hi),), :u)
+    @test b_long
+    @test occursin("…", r_long)
+    @test occursin("6 total", r_long)
+
+    # asymmetric vector bounds: "[lo, hi]" both summarized
+    r_asym, b_asym = PD._bound_repr((u = (fill(0.0, 6), collect(1.0:6.0)),), :u)
+    @test b_asym
+    @test occursin("[", r_asym)
+
+    # scalar-ish bounds fall through to "lo..hi"
+    r_scalar, b_scalar = PD._bound_repr((Δt = (0.01, 0.5),), :Δt)
+    @test b_scalar
+    @test occursin("..", r_scalar)
+
+    # _summarize_vec: empty, short, long
+    @test PD._summarize_vec(Float64[]) == ""
+    @test PD._summarize_vec([1.0, 2.0]) == "1.0, 2.0"
+    s = PD._summarize_vec(collect(1.0:7.0))
+    @test occursin("…", s) && occursin("7 total", s)
+
+    # _repr_global_bound: 2π recognition (vector form), symmetric scalar,
+    # asymmetric scalar, symmetric/asymmetric vectors, non-tuple fallback
+    @test PD._repr_global_bound(([-2π], [2π])) == "±2π"
+    @test PD._repr_global_bound((-1.5, 1.5)) == "±1.5"
+    @test PD._repr_global_bound((-0.5, 1.5)) == "[-0.5, 1.5]"
+    @test PD._repr_global_bound(([-1.0], [1.0])) == "±1.0"
+    @test occursin("[", PD._repr_global_bound(([-0.5, 0.0], [1.0, 0.5])))
+    @test PD._repr_global_bound([0.1, 0.2]) == "[0.1, 0.2]"
+end
+
+@testitem "inspect.jl system/trajectory helper branches" begin
+    using Piccolo
+    using NamedTrajectories
+
+    PD = Piccolo.Control.ProblemDisplay
+
+    # -- _system_dim: levels scalar, H_drift, size-only fallback, nothing --
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
+    @test PD._system_dim(sys) == 2          # via :levels (a scalar Int)
+    struct DriftOnlySys
+        H_drift::Matrix{ComplexF64}
+    end
+    @test PD._system_dim(DriftOnlySys(PAULIS.Z)) == 2
+    struct SizedSys end
+    Base.size(::SizedSys) = (3, 3)
+    Base.size(::SizedSys, d::Integer) = 1 <= d <= 2 ? 3 : 1
+    @test PD._system_dim(SizedSys()) == 3
+    struct OpaqueSys end
+    @test PD._system_dim(OpaqueSys()) == 0
+
+    # -- _subsystem_levels: scalar → nothing, vector → collected, other → nothing --
+    @test PD._subsystem_levels(sys) === nothing
+    struct LevelsVecSys
+        levels::Vector{Int}
+    end
+    @test PD._subsystem_levels(LevelsVecSys([2, 3])) == [2, 3]
+    struct LevelsAnySys
+        levels
+    end
+    @test PD._subsystem_levels(LevelsAnySys("not-levels")) === nothing
+
+    # -- _system_globals: no global components, matching globals, non-scalars --
+    traj_plain =
+        NamedTrajectory((u = randn(1, 5), Δt = fill(0.1, 5)); timestep = :Δt, controls = :u)
+    @test isempty(PD._system_globals(sys, traj_plain))
+
+    traj_glob = NamedTrajectory(
+        (u = randn(1, 5), Δt = fill(0.1, 5));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.5, 1.0],
+        global_components = (δ = 1:1, junk = 2:2),
+    )
+    struct GlobalsSys
+        global_params::NamedTuple
+    end
+    gsys = GlobalsSys((δ = 0.5, χ = 0.2, M = [1.0 2.0; 3.0 4.0]))
+    pairs_out = PD._system_globals(gsys, traj_glob)
+    @test pairs_out == [:δ => 0.5]                     # only names shared with traj
+    @test isempty(PD._system_globals(sys, traj_glob))  # no global_params on QuantumSystem
+
+    # -- _Δt_range: missing, present, empty --
+    @test PD._Δt_range(traj_plain) === nothing
+    traj_bnd = NamedTrajectory(
+        (u = randn(1, 5), Δt = fill(0.1, 5));
+        timestep = :Δt,
+        controls = :u,
+        bounds = (Δt = ([0.01], [0.5]),),
+    )
+    @test PD._Δt_range(traj_bnd) == (0.01, 0.5)
+
+    # -- _safe_duration: get_duration works on ordinary trajectories --
+    # (N = 5 knots × Δt = 0.1 → 4 intervals)
+    @test PD._safe_duration(traj_plain) ≈ 0.4
+    struct NoDurationTraj end
+    @test isnan(PD._safe_duration(NoDurationTraj()))
+
+    # -- _count_bounded_vars: per-knot bounded components + globals --
+    traj_count = NamedTrajectory(
+        (x = randn(2, 4), u = randn(1, 4), Δt = fill(0.1, 4));
+        timestep = :Δt,
+        controls = :u,
+        bounds = (x = (-ones(2), ones(2)), u = 1.0),
+        global_data = [0.7],
+        global_components = (a = 1:1,),
+    )
+    # x contributes dim 2 × N 4 = 8; u contributes 1 × 4 = 4; globals 1
+    @test PD._count_bounded_vars(traj_count) == 13
+end
+
+@testitem "inspect.jl goal summaries and integrator rendering" begin
+    using Piccolo
+    using NamedTrajectories
+    using LinearAlgebra
+
+    PD = Piccolo.Control.ProblemDisplay
+
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
+    times = collect(range(0.0, 1.0, length = 6))
+    pulse = ZeroOrderPulse(0.1 * randn(1, 6), times)
+
+    # Unitary goal summaries: plain matrix vs EmbeddedOperator
+    qtraj_u = UnitaryTrajectory(sys, pulse, GATES[:X])
+    @test occursin("2×2", PD._goal_summary(qtraj_u))
+    op = EmbeddedOperator(GATES[:X], 1:2, [2])
+    qtraj_e = UnitaryTrajectory(sys, pulse, op)
+    @test occursin("EmbeddedOperator", PD._goal_summary(qtraj_e))
+    @test occursin("[2]", PD._goal_summary(qtraj_e))
+
+    # Ket / MultiKet / Density / Sampling summaries
+    ψ0, ψ1 = ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]
+    qtraj_k = KetTrajectory(sys, pulse, ψ0, ψ1)
+    @test occursin("ψ_init", PD._goal_summary(qtraj_k))
+
+    qtraj_mk = MultiKetTrajectory(sys, pulse, [ψ0, ψ1], [ψ1, ψ0])
+    @test occursin("2 state transfers", PD._goal_summary(qtraj_mk))
+
+    osys = OpenQuantumSystem(sys)
+    qtraj_d = DensityTrajectory(osys, pulse, ψ0 * ψ0', ψ1 * ψ1')
+    @test PD._goal_summary(qtraj_d) == "ρ_init → ρ_goal"
+
+    qtraj_s = SamplingTrajectory(qtraj_u, [sys, sys])
+    @test occursin("sampled ensemble (n=2)", PD._goal_summary(qtraj_s))
+
+    # _render_integrator: state_name / variable / name / bare typename
+    struct IntA
+        state_name::Symbol
+    end
+    struct IntB
+        variable::Symbol
+    end
+    struct IntC
+        name::Symbol
+    end
+    struct IntD end
+    @test PD._render_integrator(IntA(:ψ̃)) == "IntA(:ψ̃)"
+    @test PD._render_integrator(IntB(:u)) == "IntB(:u)"
+    @test PD._render_integrator(IntC(:ρ)) == "IntC(:ρ)"
+    @test PD._render_integrator(IntD()) == "IntD"
+end
+
+@testitem "inspect.jl objective decomposition helpers" begin
+    using Piccolo
+    using NamedTrajectories
+    using DirectTrajOpt
+
+    PD = Piccolo.Control.ProblemDisplay
+
+    N = 5
+    traj = NamedTrajectory(
+        (x = randn(2, N), u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Flat objective: single (obj, 1.0) pair
+    J_flat = QuadraticRegularizer(:u, traj, 0.5)
+    terms, total = PD._objective_terms(J_flat, traj)
+    @test length(terms) == 1
+    @test terms[1].weight == 1.0
+    @test terms[1].value ≈ objective_value(J_flat, traj)
+    @test total ≈ terms[1].value
+
+    # Composite objective: zip(objectives, weights) branch
+    J_comp = CompositeObjective([J_flat, QuadraticRegularizer(:x, traj, 0.25)], [2.0, 0.5])
+    terms_c, total_c = PD._objective_terms(J_comp, traj)
+    @test length(terms_c) == 2
+    @test terms_c[1].weight == 2.0
+    @test terms_c[2].weight == 0.5
+    @test total_c ≈
+          2 * terms_c[1].value / 2 + sum(terms_c[t].value for t = 1:2) - terms_c[1].value
+
+    # _objective_label: name symbol, state_name symbol, bare
+    @test occursin("(:u)", PD._objective_label(J_flat))
+    struct NamedStateObj
+        state_name::Symbol
+    end
+    @test PD._objective_label(NamedStateObj(:ψ̃)) == "NamedStateObj(:ψ̃)"
+    struct BareObj end
+    @test PD._objective_label(BareObj()) == "BareObj"
+
+    # _try_eval_objective: value, non-number, error
+    struct ValObj end
+    (::ValObj)(traj) = 3.25
+    @test PD._try_eval_objective(ValObj(), traj) == 3.25
+    struct NonNumberObj end
+    (::NonNumberObj)(traj) = "not a number"
+    @test PD._try_eval_objective(NonNumberObj(), traj) == 0.0
+    struct ThrowingObj end
+    (::ThrowingObj)(traj) = error("boom")
+    @test isnan(PD._try_eval_objective(ThrowingObj(), traj))
+end
+
+@testitem "inspect.jl constraint classification helpers" begin
+    using Piccolo
+    using NamedTrajectories
+    using DirectTrajOpt
+    using LinearAlgebra
+
+    PD = Piccolo.Control.ProblemDisplay
+
+    N = 6
+    traj = NamedTrajectory(
+        (ψ̃ = randn(4, N), u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # -- _constraint_name: final_fidelity / fidelity property branches --
+    struct FinalFidCon
+        final_fidelity::Float64
+    end
+    @test PD._constraint_name(FinalFidCon(0.99), "FinalFidCon", traj) ==
+          "FinalFidelity F ≥ 0.99"
+    struct FidCon
+        fidelity::Float64
+    end
+    @test PD._constraint_name(FidCon(0.95), "FidCon", traj) == "FinalFidelity F ≥ 0.95"
+
+    # -- NonlinearKnotPointConstraint patterns --
+    g_ineq = x -> [1.0 - x[1]]
+    terminal_ineq =
+        NonlinearKnotPointConstraint(g_ineq, :ψ̃, traj; equality = false, times = [N])
+    @test occursin(
+        "Terminal fidelity bound",
+        PD._constraint_name(terminal_ineq, "NonlinearKnotPointConstraint", traj),
+    )
+
+    eq_con = NonlinearKnotPointConstraint(x -> [0.0], [:ψ̃, :u], traj; equality = true)
+    @test occursin(
+        "Knot-point eq",
+        PD._constraint_name(eq_con, "NonlinearKnotPointConstraint", traj),
+    )
+
+    ineq_nonterminal = NonlinearKnotPointConstraint(
+        x -> [1.0 - x[1]],
+        :ψ̃,
+        traj;
+        equality = false,
+        times = 1:(N-2),
+    )
+    @test occursin(
+        "Knot-point ineq",
+        PD._constraint_name(ineq_nonterminal, "NonlinearKnotPointConstraint", traj),
+    )
+
+    # -- var label extraction: name / var_names / state_name --
+    struct NamedCon
+        name::Symbol
+    end
+    @test PD._constraint_name(NamedCon(:my_thing), "NamedCon", traj) == "NamedCon:my_thing"
+    struct StateNameCon
+        state_name::Symbol
+    end
+    @test PD._constraint_name(StateNameCon(:ψ̃), "StateNameCon", traj) == "StateNameCon:ψ̃"
+    struct BareCon end
+    @test PD._constraint_name(BareCon(), "BareCon", traj) == "BareCon"
+
+    # _constraint_var_label through the var_names branch
+    @test occursin(":ψ̃", PD._constraint_name(eq_con, "NonlinearKnotPointConstraint", traj))
+
+    # -- _constraint_kind --
+    bnd = BoundsConstraint(:u, collect(1:N), 1.0)
+    @test PD._constraint_kind(bnd, "BoundsConstraint") == :bnd
+    @test PD._constraint_kind(1, "GlobalEqualityConstraint") == :eq
+    @test PD._constraint_kind(1, "TimeStepsAllEqualConstraint") == :eq
+    @test PD._constraint_kind(1, "TimeConsistencyConstraint") == :eq
+    @test PD._constraint_kind(terminal_ineq, "NonlinearKnotPointConstraint") == :ineq
+    @test PD._constraint_kind(eq_con, "NonlinearKnotPointConstraint") == :eq
+    @test PD._constraint_kind(1, "SomethingFidelity") == :ineq
+    @test PD._constraint_kind(1, "SomethingLeakage") == :ineq
+    @test PD._constraint_kind(1, "MysteryConstraint") == :ineq
+
+    # -- _constraint_dim: g_dim / dim / n_constraints / fallback --
+    @test PD._constraint_dim(terminal_ineq) == 1
+    struct DimCon
+        dim::Int
+    end
+    @test PD._constraint_dim(DimCon(7)) == 7
+    struct NCon
+        n_constraints::Int
+    end
+    @test PD._constraint_dim(NCon(4)) == 4
+    @test PD._constraint_dim(BareCon()) == 1
+
+    # -- _try_eval_constraint: bounds → 0.0, real eval → max|g|, error → NaN --
+    @test PD._try_eval_constraint(bnd, traj, :bnd) == 0.0
+    v = PD._try_eval_constraint(terminal_ineq, traj, :ineq)
+    @test v isa Float64
+    @test PD._try_eval_constraint(BareCon(), traj, :ineq) |> isnan
+
+    # -- _classify_and_eval end-to-end on a real constraint --
+    ci = PD._classify_and_eval(terminal_ineq, traj)
+    @test ci.kind == :ineq
+    @test ci.dim == 1
+    @test ci.violation == v
+    @test ci.feasible == (v < 1e-6)
+
+    # -- _integrator_dim: state_dim / dim / n / fallback --
+    struct SDimInt
+        state_dim::Int
+    end
+    struct NInt
+        n::Int
+    end
+    @test PD._integrator_dim(SDimInt(4), traj) == 4 * (N - 1)
+    @test PD._integrator_dim(DimCon(3), traj) == 3 * (N - 1)
+    @test PD._integrator_dim(NInt(2), traj) == 2 * (N - 1)
+    @test PD._integrator_dim(BareCon(), traj) == N - 1
+end
+
+@testitem "inspect.jl free-phase fidelity helpers" begin
+    using Piccolo
+    using NamedTrajectories
+    using LinearAlgebra
+
+    PD = Piccolo.Control.ProblemDisplay
+
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
+    times = collect(range(0.0, 1.0, length = 5))
+    pulse = ZeroOrderPulse(0.1 * randn(1, 5), times)
+
+    # _fidelity_at on a UnitaryTrajectory with a plain-matrix goal: nothing
+    qtraj_u = UnitaryTrajectory(sys, pulse, GATES[:X])
+    traj = NamedTrajectory(
+        (Ũ⃗ = randn(8, 5), u = randn(1, 5), Δt = fill(0.25, 5));
+        controls = :u,
+        timestep = :Δt,
+        global_data = [0.3],
+        global_components = (φ_1 = 1:1,),
+    )
+    @test PD._fidelity_at(qtraj_u, traj, [0.3]) === nothing
+
+    # _fidelity_at on a KetTrajectory: QuantumSystem.levels is a scalar Int, so
+    # _phased_ket_goal has no matching method — the MethodError is caught by
+    # _fidelity_with_stored_phases (which then reports F_with_phase = nothing).
+    qtraj_k = KetTrajectory(sys, pulse, ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0])
+    traj_ket = NamedTrajectory(
+        (ψ̃ = randn(4, 5), u = randn(1, 5), Δt = fill(0.25, 5));
+        controls = :u,
+        timestep = :Δt,
+        global_data = [0.3],
+        global_components = (φ_1 = 1:1,),
+    )
+    @test_throws MethodError PD._fidelity_at(qtraj_k, traj_ket, [0.3])
+    @test PD._fidelity_with_stored_phases(qtraj_k, traj_ket) === nothing
+
+    # _fidelity_with_stored_phases: no φ_ globals → nothing
+    traj_nophi = NamedTrajectory(
+        (ψ̃ = randn(4, 5), u = randn(1, 5), Δt = fill(0.25, 5));
+        controls = :u,
+        timestep = :Δt,
+        global_data = [0.7],
+        global_components = (δ = 1:1,),
+    )
+    @test PD._fidelity_with_stored_phases(qtraj_k, traj_nophi) === nothing
+
+    # _phased_ket_goal: matching θ applies e^{iθ} to |1⟩
+    ψ = ComplexF64[1.0, 1.0] / √2
+    phased = PD._phased_ket_goal(ψ, [π], [2])
+    @test phased ≈ ComplexF64[1.0, -1.0] / √2
+    # Length mismatch: goal returned unchanged
+    @test PD._phased_ket_goal(ψ, [π, π], [2]) === ψ
+    # Multi-level number-operator rotation: level s gets e^{isθ}
+    ψ3 = ComplexF64[0.0, 1.0, 0.0]
+    phased3 = PD._phased_ket_goal(ψ3, [π / 2], [3])
+    @test phased3 ≈ ComplexF64[0.0, im, 0.0]
+
+    # _initial_fidelities: F computed, F_phase nothing without φ_ globals
+    F, F_phase = PD._initial_fidelities(qtraj_k, traj_nophi)
+    @test F isa Float64
+    @test 0.0 <= F <= 1.0
+    @test F_phase === nothing
+
+    # _typename strips type parameters
+    @test PD._typename([1.0, 2.0]) == "Array"
+    @test PD._typename(GATES[:X]) == "Array"
+end
+
+@testitem "inspect + show_problem on a solved-shape SmoothPulseProblem" begin
+    using Piccolo
+    using DirectTrajOpt
+    using NamedTrajectories
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(11)
+    T, N = 5.0, 20
+    sys = QuantumSystem(GATES[:Z], [GATES[:X], GATES[:Y]], [1.0, 1.0])
+    ψ_init = ComplexF64[1.0, 0.0]
+    ψ_goal = ComplexF64[0.0, 1.0]
+    pulse = ZeroOrderPulse(0.1 * randn(2, N), collect(range(0.0, T, length = N)))
+    qtraj = KetTrajectory(sys, pulse, ψ_init, ψ_goal)
+
+    qcp = SmoothPulseProblem(
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
+        piccolo_options = PiccoloOptions(display = :silent),
+    )
+
+    ins = inspect(qcp)
+    @test ins isa ProblemInspection
+    @test ins.traj_typename == "KetTrajectory"
+    @test ins.pulse_typename == "ZeroOrderPulse"
+    @test ins.sys_dim == 2
+    @test ins.n_drives == 2
+    @test ins.subsystem_levels === nothing
+    @test ins.N == N
+    @test ins.T ≈ T
+    @test ins.goal_summary isa String
+    @test !isempty(ins.components)
+    @test !isempty(ins.integrator_summary)
+    @test length(ins.constraints) >= 3  # dynamics + derivative integrators
+    @test ins.F_current isa Float64
+    @test ins.F_with_phase === nothing   # no φ_ globals on this problem
+    @test ins.n_vars > 0
+    @test ins.n_eq > 0
+    @test ins.n_bounded_vars > 0
+
+    # Compact one-line show: Base.show(io, qcp)
+    s = sprint(show, qcp)
+    @test occursin("QuantumControlProblem", s)
+    @test occursin("KetTrajectory", s)
+    @test occursin("ZeroOrderPulse", s)
+    @test occursin("vars", s)
+    @test occursin("eq", s)
+
+    # Rich text/plain show → :standard tree
+    s_std = sprint(show, MIME"text/plain"(), qcp)
+    @test occursin("System", s_std)
+    @test occursin("Trajectory", s_std)
+    @test occursin("Goal", s_std)
+    @test occursin("Objective", s_std)
+    @test occursin("Constraints", s_std)
+    @test occursin("Status", s_std)
+    @test occursin("Hint:", s_std)      # drill-down hint at :standard level
+
+    # Explicit entry points: :standard, :full, and the ArgumentError guard
+    io = IOBuffer()
+    show_problem(io, qcp; detail = :standard)
+    @test occursin("QuantumControlProblem", String(take!(io)))
+    io = IOBuffer()
+    show_problem(io, qcp; detail = :full)
+    s_full = String(take!(io))
+    @test occursin("Pulse (current)", s_full)  # _print_full_extras ran
+    @test occursin("time", s_full)             # ASCII pulse plot rendered
+    @test !occursin("Hint:", s_full)           # hint replaced by extras at :full
+    @test_throws ArgumentError show_problem(IOBuffer(), qcp; detail = :bogus)
+
+    # stdout convenience method runs without error
+    show_problem(qcp; detail = :standard)
+end
+
+@testitem "inspect reports phase-adjusted fidelity for free-phase problems" begin
+    using Piccolo
+    using DirectTrajOpt
+    using NamedTrajectories
+    using LinearAlgebra
+
+    # Free-phase unitary problem: the trajectory carries φ_1, so the inspector
+    # must compute F_with_phase via the phased EmbeddedOperator goal.
+    σx = ComplexF64[0 1; 1 0]
+    H_drift_3 = ComplexF64[0 0 0; 0 1 0; 0 0 2]
+    H_drive_3 = ComplexF64[0 1 0; 1 0 1; 0 1 0] / √2
+    sys = QuantumSystem(H_drift_3, [H_drive_3], [1.0])
+
+    T, N = 10.0, 21
+    times = collect(range(0.0, T, length = N))
+    pulse = LinearSplinePulse(0.1 * ones(1, N), times)
+    U_goal = EmbeddedOperator(σx, [1, 2], [3])
+    qtraj = UnitaryTrajectory(sys, pulse, U_goal)
+
+    qcp = SplinePulseProblem(
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
+        free_phase = true,
+        piccolo_options = PiccoloOptions(display = :silent),
+    )
+
+    ins = inspect(qcp)
+    @test haskey(get_trajectory(qcp).global_components, :φ_1)
+    @test ins.F_current isa Float64
+    @test ins.F_with_phase isa Float64
+    @test 0.0 <= ins.F_with_phase <= 1.0
+    # Before any solve, φ_1 = 0, so the phase-adjusted F equals the raw F
+    @test ins.F_with_phase ≈ ins.F_current
+
+    # The Globals section renders the φ_1 row with :free_phase status
+    s = sprint(show, MIME"text/plain"(), qcp)
+    @test occursin("φ_1", s)
+    @test occursin("free_phase", s)
+
+    # Global bounds on φ_1 surface as a ±2π row in the inspection
+    @test any(g -> g.name === :φ_1, ins.globals)
+end
+
+@testitem "_maybe_display respects the display tier" begin
+    using Piccolo
+    using DirectTrajOpt
+    using NamedTrajectories
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(5)
+    T, N = 5.0, 10
+    sys = QuantumSystem(GATES[:Z], [GATES[:X]], [1.0])
+    pulse = ZeroOrderPulse(0.1 * randn(1, N), collect(range(0.0, T, length = N)))
+    qtraj = KetTrajectory(sys, pulse, ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0])
+
+    # :detailed runs show_problem(detail=:full) — the pulse plot + sparsity view
+    qcp_detailed =
+        SmoothPulseProblem(qtraj, N; piccolo_options = PiccoloOptions(display = :detailed))
+    @test qcp_detailed isa QuantumControlProblem
+
+    # :silent constructs with no output at all
+    qcp_silent =
+        SmoothPulseProblem(qtraj, N; piccolo_options = PiccoloOptions(display = :silent))
+    @test qcp_silent isa QuantumControlProblem
 end

--- a/src/control/templates/_problem_templates.jl
+++ b/src/control/templates/_problem_templates.jl
@@ -727,4 +727,216 @@ end
     @test _safe_bound_times(:x, traj3) == collect(2:(N-1))
 end
 
+
+@testitem "setup_free_phase_globals! variants" begin
+    using Piccolo
+    using .ProblemTemplates: setup_free_phase_globals!
+
+    # Both dicts nothing: fresh dicts created, phases default to 0
+    θ_names, gd, gb = setup_free_phase_globals!(2, nothing, nothing)
+    @test θ_names == [:φ_1, :φ_2]
+    @test gd[:φ_1] == [0.0]
+    @test gd[:φ_2] == [0.0]
+    @test gb[:φ_1] == (-2π, 2π)
+    @test gb[:φ_2] == (-2π, 2π)
+
+    # Existing dicts are mutated; a pre-set bound is left alone (haskey guard)
+    gd = Dict(:φ_1 => [0.25], :other => [1.0])
+    gb = Dict{Symbol,Union{Float64,Tuple{Float64,Float64}}}(:φ_1 => (0.0, Float64(π)))
+    θ_names, gd2, gb2 = setup_free_phase_globals!(1, gd, gb)
+    @test gd2 === gd                       # mutated in place
+    @test gd[:φ_1] == [0.0]                # phase value reset to the default 0
+    @test gb2 === gb
+    @test gb[:φ_1] == (0.0, Float64(π))    # pre-existing bound preserved
+    @test !haskey(gb, :φ_2)                # only n_qubits bounds are touched
+    @test gd[:other] == [1.0]              # unrelated entries untouched
+
+    # initial_phases seed the values; wrong length asserts
+    _, gd3, _ = setup_free_phase_globals!(2, nothing, nothing; initial_phases = [0.1, 0.2])
+    @test gd3[:φ_1] == [0.1]
+    @test gd3[:φ_2] == [0.2]
+    @test_throws AssertionError setup_free_phase_globals!(
+        2,
+        nothing,
+        nothing;
+        initial_phases = [0.1],
+    )
+
+    # verbose runs without error
+    _, _, _ = setup_free_phase_globals!(1, nothing, nothing; verbose = true)
+end
+
+@testitem "_fmt_bounds formatting variants" begin
+    using Piccolo
+    using .ProblemTemplates: _fmt_bounds
+
+    @test _fmt_bounds(0.5) == "±0.5"
+    @test _fmt_bounds((-1.0, 1.0)) == "±1.0"
+    @test _fmt_bounds((-0.2, 0.8)) == "[-0.2, 0.8]"
+    @test _fmt_bounds([0.1, 0.2]) == "±[0.1, 0.2]"
+    @test _fmt_bounds(([-1.0, -0.5], [1.0, 0.5])) == "±[1.0, 0.5]"
+    # Asymmetric vector bounds render as "[lo, hi]"
+    @test occursin("[", _fmt_bounds(([-0.5, 0.0], [1.0, 0.5])))
+    @test _fmt_bounds(:weird) == "weird"    # fallback
+end
+
+@testitem "_unbind_state! and _safe_bound_times remaining branches" begin
+    using Piccolo
+    using NamedTrajectories
+
+    _unbind_state! = Piccolo.Control.ProblemTemplates._unbind_state!
+    _safe_bound_times = Piccolo.Control.ProblemTemplates._safe_bound_times
+
+    N = 5
+    traj = NamedTrajectory(
+        (x = rand(2, N), u = rand(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+        bounds = (x = (-ones(2), ones(2)), u = 1.0),
+    )
+
+    # Name not present in bounds: no-op, returns nothing
+    @test _unbind_state!(traj, :u_not_there) === nothing
+    @test all(traj.bounds[:x][1] .== -1.0)
+
+    # Final-only: times 1:(N-1)
+    traj_fin = NamedTrajectory(
+        (x = rand(2, N), u = rand(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+        final = (x = rand(2),),
+    )
+    @test _safe_bound_times(:x, traj_fin) == collect(1:(N-1))
+end
+
+@testitem "apply_piccolo_options! remaining branches" begin
+    using Piccolo
+    using NamedTrajectories
+    using DirectTrajOpt
+
+    apply_piccolo_options! = Piccolo.Control.ProblemTemplates.apply_piccolo_options!
+
+    N = 6
+    traj = NamedTrajectory(
+        (ψ̃ = rand(4, N), u = rand(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Leakage with a single Symbol state name: converted to vector form
+    opts = PiccoloOptions(
+        leakage_constraint = true,
+        leakage_constraint_value = 0.01,
+        display = :silent,
+    )
+    cons = AbstractConstraint[]
+    J = apply_piccolo_options!(
+        opts,
+        cons,
+        traj;
+        state_names = :ψ̃,
+        state_leakage_indices = [2, 3],
+    )
+    @test J isa AbstractObjective
+    # LeakageConstraint(...) builds a NonlinearKnotPointConstraint on the leakage indices
+    leak = filter(c -> c isa NonlinearKnotPointConstraint, cons)
+    @test length(leak) == 1
+
+    # timesteps_all_equal adds an AllEqualConstraint on the timestep variable
+    cons2 = AbstractConstraint[]
+    apply_piccolo_options!(
+        PiccoloOptions(timesteps_all_equal = true, display = :silent),
+        cons2,
+        traj;
+    )
+    ae = filter(c -> c isa AllEqualConstraint, cons2)
+    @test length(ae) == 1
+    @test ae[1].var_name === :Δt
+
+    # complex_control_norm_constraint_name adds a nonlinear inequality on :u
+    cons3 = AbstractConstraint[]
+    apply_piccolo_options!(
+        PiccoloOptions(complex_control_norm_constraint_name = :u, display = :silent),
+        cons3,
+        traj;
+    )
+    @test length(cons3) == 1
+    @test cons3[1] isa NonlinearKnotPointConstraint
+    @test cons3[1].equality == false
+
+    # :detailed display drives the verbose println branches without error
+    cons4 = AbstractConstraint[]
+    apply_piccolo_options!(
+        PiccoloOptions(
+            leakage_constraint = true,
+            timesteps_all_equal = true,
+            complex_control_norm_constraint_name = :u,
+            bound_state = false,
+            bound_state_l2 = true,
+            display = :detailed,
+        ),
+        cons4,
+        traj;
+        state_names = :ψ̃,
+        state_leakage_indices = [2, 3],
+    )
+    @test !isempty(cons4)
+end
+
+@testitem "_apply_piccolo_options leakage-index resolution" begin
+    using Piccolo
+    using NamedTrajectories
+    using DirectTrajOpt
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(9)
+    T, N = 5.0, 10
+    sys = QuantumSystem(GATES[:Z], [GATES[:X], GATES[:Y]], [1.0, 1.0])
+    pulse = ZeroOrderPulse(0.1 * randn(2, N), collect(range(0.0, T, length = N)))
+
+    # ── UnitaryTrajectory: user override + EmbeddedOperator auto-derivation ──
+    op = EmbeddedOperator(GATES[:X], 1:2, 2)
+    qtraj_u = UnitaryTrajectory(sys, pulse, op)
+    cons = AbstractConstraint[]
+    J = Piccolo.Control.ProblemTemplates._apply_piccolo_options(
+        qtraj_u,
+        PiccoloOptions(leakage_constraint = true, display = :silent),
+        cons,
+        NamedTrajectory(qtraj_u, N),
+        :Ũ⃗;
+        state_leakage_indices = [5, 6, 7, 8],
+    )
+    @test J isa AbstractObjective
+    @test length(filter(c -> c isa NonlinearKnotPointConstraint, cons)) == 1
+
+    # ── MultiKetTrajectory: single vector broadcast to every state ──
+    ψ0 = ComplexF64[1.0, 0.0]
+    ψ1 = ComplexF64[0.0, 1.0]
+    qtraj_mk = MultiKetTrajectory(sys, pulse, [ψ0, ψ1], [ψ1, ψ0])
+    cons_mk = AbstractConstraint[]
+    Piccolo.Control.ProblemTemplates._apply_piccolo_options(
+        qtraj_mk,
+        PiccoloOptions(leakage_constraint = true, display = :silent),
+        cons_mk,
+        NamedTrajectory(qtraj_mk, N),
+        [:ψ̃1, :ψ̃2];
+        state_leakage_indices = [3, 4],
+    )
+    # one leakage constraint per state
+    @test length(filter(c -> c isa NonlinearKnotPointConstraint, cons_mk)) == 2
+
+    # ── MultiKetTrajectory: per-state vectors pass through untouched ──
+    cons_mk2 = AbstractConstraint[]
+    Piccolo.Control.ProblemTemplates._apply_piccolo_options(
+        qtraj_mk,
+        PiccoloOptions(leakage_constraint = true, display = :silent),
+        cons_mk2,
+        NamedTrajectory(qtraj_mk, N),
+        [:ψ̃1, :ψ̃2];
+        state_leakage_indices = [[3, 4], [3, 4]],
+    )
+    @test length(filter(c -> c isa NonlinearKnotPointConstraint, cons_mk2)) == 2
+end
+
 end

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -1709,3 +1709,106 @@ end
     # than a problem without leakage
     @test length(qcp.prob.constraints) >= 2
 end
+
+@testitem "SmoothPulseProblem free_phase error contract (single trajectory)" begin
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(21)
+    T, N = 5.0, 10
+    sys = QuantumSystem(GATES[:Z], [GATES[:X], GATES[:Y]], [1.0, 1.0])
+    pulse = ZeroOrderPulse(0.1 * randn(2, N), collect(range(0.0, T, length = N)))
+
+    # KetTrajectory: no subsystem_levels plumbing on this method at all
+    qtraj_k = KetTrajectory(sys, pulse, ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0])
+    @test_throws ErrorException SmoothPulseProblem(qtraj_k, N; free_phase = true)
+
+    # UnitaryTrajectory with a plain-matrix goal: free_phase requires EmbeddedOperator
+    qtraj_u = UnitaryTrajectory(sys, pulse, GATES[:X])
+    @test_throws AssertionError SmoothPulseProblem(qtraj_u, N; free_phase = true)
+
+    # EmbeddedOperator goal: the θ globals are set up, then construction stops
+    # at the integrator requirement (BilinearIntegrator does not carry globals).
+    op = EmbeddedOperator(GATES[:X], 1:2, 2)
+    qtraj_e = UnitaryTrajectory(sys, pulse, op)
+    @test_throws ErrorException SmoothPulseProblem(
+        qtraj_e,
+        N;
+        free_phase = true,
+        piccolo_options = PiccoloOptions(display = :silent),
+    )
+end
+
+@testitem "SmoothPulseProblem builds global_data from system global_params" begin
+    using DirectTrajOpt
+    using NamedTrajectories
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(31)
+    T, N = 2.0, 10
+    sys = QuantumSystem(
+        GATES[:Z],
+        [GATES[:X], GATES[:Y]],
+        [1.0, 1.0];
+        global_params = (δ = 0.1,),
+    )
+    pulse = ZeroOrderPulse(0.1 * randn(2, N), collect(range(0.0, T, length = N)))
+
+    # Single-trajectory path: global_data seeded from sys.global_params
+    qtraj = KetTrajectory(sys, pulse, ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0])
+    qcp = SmoothPulseProblem(
+        qtraj,
+        N;
+        piccolo_options = PiccoloOptions(display = :silent, timesteps_all_equal = true),
+    )
+    traj = get_trajectory(qcp)
+    @test haskey(traj.global_components, :δ)
+    @test traj.global_data[traj.global_components[:δ]] ≈ [0.1]
+
+    # MultiKet path: same seeding
+    ψ0 = ComplexF64[1.0, 0.0]
+    ψ1 = ComplexF64[0.0, 1.0]
+    qtraj_mk = MultiKetTrajectory(sys, pulse, [ψ0, ψ1], [ψ1, ψ0])
+    qcp_mk = SmoothPulseProblem(
+        qtraj_mk,
+        N;
+        piccolo_options = PiccoloOptions(display = :silent, timesteps_all_equal = true),
+    )
+    @test haskey(get_trajectory(qcp_mk).global_components, :δ)
+end
+
+@testitem "SmoothPulseProblem accepts prebuilt integrators" begin
+    using DirectTrajOpt
+    using NamedTrajectories
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(41)
+    T, N = 5.0, 10
+    sys = QuantumSystem(GATES[:Z], [GATES[:X], GATES[:Y]], [1.0, 1.0])
+    pulse = ZeroOrderPulse(0.1 * randn(2, N), collect(range(0.0, T, length = N)))
+
+    # Single integrator (not a vector) for the single-trajectory method
+    qtraj = KetTrajectory(sys, pulse, ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0])
+    qcp = SmoothPulseProblem(
+        qtraj,
+        N;
+        integrator = BilinearIntegrator(qtraj, N),
+        piccolo_options = PiccoloOptions(display = :silent, timesteps_all_equal = true),
+    )
+    @test qcp isa QuantumControlProblem
+
+    # Vector of integrators for the MultiKet method (one per state)
+    ψ0 = ComplexF64[1.0, 0.0]
+    ψ1 = ComplexF64[0.0, 1.0]
+    qtraj_mk = MultiKetTrajectory(sys, pulse, [ψ0, ψ1], [ψ1, ψ0])
+    integrators = collect(BilinearIntegrator(qtraj_mk, N))
+    qcp_mk = SmoothPulseProblem(
+        qtraj_mk,
+        N;
+        integrator = integrators,
+        piccolo_options = PiccoloOptions(display = :silent, timesteps_all_equal = true),
+    )
+    @test qcp_mk isa QuantumControlProblem
+end

--- a/src/quantum/dynamics.jl
+++ b/src/quantum/dynamics.jl
@@ -1280,5 +1280,232 @@ end
     end
 end
 
+@testitem "Rollouts: fidelity and unitary_fidelity primitives" begin
+    using LinearAlgebra
+
+    # Ket fidelity: |⟨ψ_goal|ψ⟩|²
+    ψ = ComplexF64[1.0, 0.0]
+    ψ_goal = ComplexF64[1.0, 0.0]
+    @test fidelity(ψ, ψ_goal) ≈ 1.0
+    ψ_orth = ComplexF64[0.0, 1.0]
+    @test fidelity(ψ, ψ_orth) ≈ 0.0
+    ψ_mixed = normalize(ComplexF64[1.0, 1.0])
+    @test fidelity(ψ, ψ_mixed) ≈ 0.5
+    # Global phase invariance
+    @test fidelity(exp(im * 0.3) * ψ, ψ_goal) ≈ 1.0
+
+    # Density fidelity: tr(ρ ρ_goal)
+    ρ = ComplexF64[1.0 0.0; 0.0 0.0]
+    ρ_goal = ComplexF64[0.0 0.0; 0.0 1.0]
+    @test fidelity(ρ, ρ_goal) ≈ 0.0
+    @test fidelity(ρ, ρ) ≈ 1.0
+    ρ_half = ComplexF64[0.5 0.0; 0.0 0.5]
+    @test fidelity(ρ, ρ_half) ≈ 0.5
+
+    # unitary_fidelity with an explicit subspace: only the subspace block counts
+    U = GATES[:X]
+    @test unitary_fidelity(U, GATES[:X]) ≈ 1.0
+    @test unitary_fidelity(U, GATES[:Z]) ≈ 0.0
+    # A 3-level embedding of the same 2-level X: the subspace restricts the score
+    U3 = zeros(ComplexF64, 3, 3)
+    U3[1:2, 1:2] .= GATES[:X]
+    U3[3, 3] = 1.0
+    U3_goal = Matrix{ComplexF64}(I, 3, 3)
+    @test unitary_fidelity(U3, U3_goal; subspace = 1:2) ≈
+          unitary_fidelity(GATES[:X], Matrix{ComplexF64}(I, 2, 2))
+end
+
+@testitem "UnitaryODEProblem (non-operator RHS) matches the Magnus path" begin
+    using OrdinaryDiffEqTsit5
+    using OrdinaryDiffEqLinear
+    using LinearAlgebra
+
+    T, Δt = 1.0, 0.1
+    sys = QuantumSystem([PAULIS.X, PAULIS.Y], [1.0, 1.0])
+    u = t -> [t; 0.0]
+    times = 0:Δt:T
+
+    prob = UnitaryODEProblem(sys, u, times)
+    sol = solve(prob, Tsit5(); saveat = [T])
+    UT = sol.u[end]
+
+    # Same rollout through the Lie-group (operator) integrator
+    prob_op = UnitaryOperatorODEProblem(sys, u, times)
+    sol_op = solve(prob_op, MagnusGL4(); saveat = [T])
+    UT_op = sol_op.u[end]
+
+    @test size(UT) == (2, 2)
+    @test UT ≈ UT_op atol = 1e-6
+
+    # Consistency with the ket rollout: U(T) ψ0 == ψ(T)
+    ψ0 = ComplexF64[1.0, 0.0]
+    ket_prob = KetODEProblem(sys, u, ψ0, times)
+    ket_sol = solve(ket_prob, Tsit5(); saveat = [T])
+    @test UT * ψ0 ≈ ket_sol.u[end] atol = 1e-6
+
+    # Symbolic access + rename
+    sol_full = solve(prob, Tsit5())
+    @test sol_full[:U] ≈ sol_full.u
+    prob_renamed = UnitaryODEProblem(sys, u, times; state_name = :V)
+    sol_ren = solve(prob_renamed, Tsit5())
+    @test sol_ren[:V] ≈ sol_ren.u
+end
+
+@testitem "Rollouts append global params to controls in operator/RHS closures" begin
+    using OrdinaryDiffEqTsit5
+    using OrdinaryDiffEqLinear
+    using LinearAlgebra
+
+    # Function-based system carrying a global: the rollout closures must
+    # append the global values to the control vector before calling H.
+    Hfn = (u, t) -> u[2] * GATES[:Z] + u[1] * GATES[:X]
+    sys = QuantumSystem(Hfn, [1.0]; global_params = (δ = 0.25,))
+
+    T, Δt = 1.0, 0.1
+    times = 0:Δt:T
+    u = t -> [0.5]
+    ψ0 = ComplexF64[1.0, 0.0]
+
+    # Operator path (MatrixOperator update!) — globals branch of _construct_operator
+    op_prob = KetOperatorODEProblem(sys, u, ψ0, times)
+    sol_op = solve(op_prob, MagnusGL4(); saveat = [T])
+
+    # RHS path — globals branch of _construct_rhs
+    rhs_prob = KetODEProblem(sys, u, ψ0, times)
+    sol_rhs = solve(rhs_prob, Tsit5(); saveat = [T])
+
+    @test sol_op.u[end] ≈ sol_rhs.u[end] atol = 1e-6
+
+    # Expected evolution: the appended global δ=0.25 reaches the Hamiltonian
+    H = 0.25 * GATES[:Z] + 0.5 * GATES[:X]
+    @test sol_op.u[end] ≈ exp(-im * H * T) * ψ0 atol = 1e-6
+
+    # Open system with globals: DensityODEProblem drives the dissipator path
+    osys = OpenQuantumSystem(
+        GATES[:Z],
+        [GATES[:X]],
+        [1.0];
+        dissipation_operators = [1e-3 * ComplexF64[0 1; 0 0]],
+        global_params = (δ = 0.25,),
+    )
+    ρ0 = ψ0 * ψ0'
+    d_prob = DensityODEProblem(osys, u, ρ0, times)
+    d_sol = solve(d_prob, Tsit5(); saveat = [T])
+    @test tr(d_sol.u[end]) ≈ 1.0 atol = 1e-6
+    # The open system's matrix H is Z + 0.5X (globals are stored, not consumed);
+    # the dissipator is O(1e-3), so the pure-state comparison carries that scale.
+    W = exp(-im * (GATES[:Z] + 0.5 * GATES[:X]) * T)
+    @test d_sol.u[end] ≈ W * ρ0 * W' atol = 5e-3
+end
+
+@testitem "rollout_fidelity and ket_rollout across interpolation kinds" begin
+    using NamedTrajectories
+    using LinearAlgebra
+
+    T = 1.0
+    N = 10
+    sys = QuantumSystem(GATES[:Z], [GATES[:X]], [1.0])
+
+    ψ_init = ComplexF64[1.0, 0.0]
+    ψ_goal = ComplexF64[0.0, 1.0]
+
+    traj = NamedTrajectory(
+        (
+            ψ̃ = repeat(ket_to_iso(ψ_init), 1, N),
+            u = 0.3 .* ones(1, N),
+            du = zeros(1, N),
+            Δt = fill(T / (N - 1), N),
+        );
+        controls = :u,
+        timestep = :Δt,
+        initial = (ψ̃ = ket_to_iso(ψ_init),),
+        goal = (ψ̃ = ket_to_iso(ψ_goal),),
+    )
+
+    # All three interpolation kinds return a scalar fidelity in [0, 1]
+    for interp in (:constant, :linear, :cubic)
+        fid = rollout_fidelity(traj, sys; interpolation = interp)
+        @test fid isa Float64
+        @test 0.0 <= fid <= 1.0
+    end
+
+    # ket_rollout_fidelity delegates to rollout_fidelity
+    @test ket_rollout_fidelity(traj, sys; interpolation = :linear) ==
+          rollout_fidelity(traj, sys; interpolation = :linear)
+
+    # Unknown interpolation kind is rejected
+    @test_throws ErrorException rollout_fidelity(traj, sys; interpolation = :quintic)
+    @test_throws ErrorException ket_rollout_fidelity(traj, sys; interpolation = :quintic)
+
+    # Missing state component is rejected
+    @test_throws ErrorException rollout_fidelity(traj, sys; state_name = :χ̃)
+
+    # Explicit algorithm kwarg is honored (Magnus on a closed system)
+    fid_magnus = rollout_fidelity(
+        traj,
+        sys;
+        interpolation = :linear,
+        algorithm = QuantumSystems.default_algorithm(sys),
+    )
+    @test fid_magnus isa Float64
+
+    # ket_rollout returns an iso-vector trajectory sampled at the knot times
+    ψ̃_out = ket_rollout(traj, sys; interpolation = :cubic)
+    @test size(ψ̃_out) == (4, N)
+    ψ_end = iso_to_ket(ψ̃_out[:, end])
+    @test norm(ψ_end) ≈ 1.0 atol = 1e-8
+    fid_manual = fidelity(ψ_end, ψ_goal)
+    @test ket_rollout_fidelity(traj, sys; interpolation = :cubic) ≈ fid_manual atol = 1e-6
+
+    # Missing state component is rejected by ket_rollout as well
+    @test_throws ErrorException ket_rollout(traj, sys; state_name = :χ̃)
+end
+
+@testitem "unitary_rollout_fidelity and unitary_rollout across interpolation kinds" begin
+    using NamedTrajectories
+    using LinearAlgebra
+
+    T = 1.0
+    N = 10
+    sys = QuantumSystem(GATES[:Z], [GATES[:X]], [1.0])
+    U_goal = GATES[:X]
+
+    traj = NamedTrajectory(
+        (
+            Ũ⃗ = repeat(operator_to_iso_vec(Matrix{ComplexF64}(I, 2, 2)), 1, N),
+            u = 0.3 .* ones(1, N),
+            du = zeros(1, N),
+            Δt = fill(T / (N - 1), N),
+        );
+        controls = :u,
+        timestep = :Δt,
+        initial = (Ũ⃗ = operator_to_iso_vec(Matrix{ComplexF64}(I, 2, 2)),),
+        goal = (Ũ⃗ = operator_to_iso_vec(U_goal),),
+    )
+
+    for interp in (:constant, :linear, :cubic)
+        fid = unitary_rollout_fidelity(traj, sys; interpolation = interp)
+        @test fid isa Float64
+        @test 0.0 <= fid <= 1.0
+    end
+
+    # Unknown interpolation kind and missing state are rejected
+    @test_throws ErrorException unitary_rollout_fidelity(
+        traj,
+        sys;
+        interpolation = :quintic,
+    )
+    @test_throws ErrorException unitary_rollout_fidelity(traj, sys; state_name = :Ṽ⃗)
+
+    # unitary_rollout returns an iso-vec trajectory over the saved times
+    Ũ⃗_out = unitary_rollout(traj, sys; interpolation = :cubic)
+    @test size(Ũ⃗_out) == (8, N)
+    U_end = iso_vec_to_operator(Ũ⃗_out[:, end])
+    @test unitary_rollout_fidelity(traj, sys; interpolation = :cubic) ≈
+          unitary_fidelity(U_end, U_goal) atol = 1e-6
+
+    # Missing state component is rejected by unitary_rollout as well
+    @test_throws ErrorException unitary_rollout(traj, sys; state_name = :Ṽ⃗)
+end
 
 end

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -1799,3 +1799,105 @@ end
 end
 
 end # module Pulses
+
+@testitem "Pulse boundary-value :free and error branches" begin
+    using Piccolo
+
+    controls = [0.5 0.25 -0.1; -0.5 0.25 0.1]
+    times = [0.0, 0.5, 1.0]
+    derivs = [0.1 0.0 0.0; -0.1 0.0 0.0]
+
+    for P in (ZeroOrderPulse, LinearSplinePulse)
+        p_free = P(controls, times; initial_value = :free, final_value = :free)
+        @test all(isnan, p_free.initial_value)
+        @test all(isnan, p_free.final_value)
+        # Unknown symbols are rejected
+        @test_throws ErrorException P(controls, times; initial_value = :frozen)
+        @test_throws ErrorException P(controls, times; final_value = :frozen)
+    end
+
+    p_cubic_free = CubicSplinePulse(
+        controls,
+        derivs,
+        times;
+        initial_value = :free,
+        final_value = :free,
+    )
+    @test all(isnan, p_cubic_free.initial_value)
+    @test all(isnan, p_cubic_free.final_value)
+    @test_throws ErrorException CubicSplinePulse(
+        controls,
+        derivs,
+        times;
+        initial_value = :frozen,
+    )
+    @test_throws ErrorException CubicSplinePulse(
+        controls,
+        derivs,
+        times;
+        final_value = :frozen,
+    )
+end
+
+@testitem "Pulse show/summary rendering" begin
+    using Piccolo
+
+    pulse = ZeroOrderPulse([0.5 0.25], [0.0, 1.0])
+
+    # Base.show (compact) delegates to summary
+    s = sprint(show, pulse)
+    @test occursin("ZeroOrderPulse", s)
+    @test occursin("drives = 1", s)
+    @test occursin("T = 1.0", s)
+
+    # MIME text/plain rendering
+    s_full = sprint(show, MIME"text/plain"(), pulse)
+    @test occursin("ZeroOrderPulse", s_full)
+    @test occursin("drives: 1", s_full)
+    @test occursin("duration: 1.0", s_full)
+
+    # Same surface for the other pulse families
+    for p in (
+        LinearSplinePulse([0.5 0.25], [0.0, 1.0]),
+        CubicSplinePulse([0.5 0.25], [0.0 0.0], [0.0, 1.0]),
+        GaussianPulse([1.0], 0.1, 1.0),
+    )
+        @test sprint(show, p) isa String
+        @test sprint(show, MIME"text/plain"(), p) isa String
+    end
+end
+
+@testitem "Spline pulse knot accessors" begin
+    using Piccolo
+
+    times = [0.0, 0.25, 0.5, 0.75, 1.0]
+    controls = [1.0 2.0 3.0 2.0 1.0]
+    derivs = [0.0 0.0 0.0 0.0 0.0]
+
+    lin = LinearSplinePulse(controls, times)
+    @test get_knot_times(lin) == times
+    @test get_knot_count(lin) == 5
+    @test get_knot_values(lin) == controls
+
+    cub = CubicSplinePulse(controls, derivs, times)
+    @test get_knot_times(cub) == times
+    @test get_knot_count(cub) == 5
+    @test get_knot_values(cub) == controls
+    @test get_knot_derivatives(cub) == derivs
+
+    zop = ZeroOrderPulse(controls, times)
+    @test get_knot_times(zop) == times
+
+    # Analytic pulses: knots are just the endpoints; composite unions them
+    g = GaussianPulse([1.0], 0.1, 1.0)
+    @test get_knot_times(g) == [0.0, 1.0]
+    e = ErfPulse([1.0], 0.1, 2.0)
+    @test get_knot_times(e) == [0.0, 2.0]
+    f = FunctionPulse(t -> [sin(t)], 1.0, 1)
+    @test get_knot_times(f) == [0.0, 1.0]
+    comp = CompositePulse(
+        [ZeroOrderPulse([0.0 0.0 0.0 0.0], [0.0, 0.25, 0.5, 1.0]), g],
+        :concatenate,
+    )
+    @test get_knot_times(comp) == [0.0, 0.25, 0.5, 1.0]
+end

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -1006,6 +1006,18 @@ end
     H_y = sparse(ComplexF64[0 -im; im 0])
     omega = 2.0
 
+    # Modulated drift with NO drives: the isempty(drives) branch builds
+    # H/G purely from modulated drift terms.
+    sys0 = QuantumSystem(H_z => t -> cos(omega * t), AbstractDrive[], Float64[])
+    @test sys0 isa QuantumSystem
+    @test sys0.n_drives == 0
+    @test sys0.levels == 2
+    @test sys0.time_dependent
+    @test sys0.H([1.0], 0.0) ≈ H_z
+    @test sys0.H([1.0], π / omega) ≈ -H_z
+    # G matches the isomorphism of the same drift-only Hamiltonian
+    @test sys0.G((), 0.3) ≈ Piccolo.Isomorphisms.G(H_z * cos(omega * 0.3))
+
     # Modulated drive: H_x => t -> cos(omega*t)
     sys1 = QuantumSystem(H_z, [H_x => t -> cos(omega * t), H_y], [1.0, 1.0])
     @test sys1.n_drives == 2
@@ -1045,4 +1057,105 @@ end
     @test sys2.H(u, 0.0) ≈ H_z * cos(0.0) + 1.0 * H_x
     t_test = 0.3
     @test sys2.H(u, t_test) ≈ H_z * cos(omega * t_test) + 1.0 * H_x
+end
+
+@testitem "QuantumSystem typed-drives no-drift constructor" begin
+    using Piccolo
+    using SparseArrays
+
+    H_x = sparse(ComplexF64[0 1; 1 0])
+    H_y = sparse(ComplexF64[0 -im; im 0])
+
+    # QuantumSystem(drives, bounds): zero drift inferred from the first drive
+    sys = QuantumSystem([LinearDrive(H_x, 1), LinearDrive(H_y, 2)], [1.0, 1.0])
+    @test sys isa QuantumSystem
+    @test get_drift(sys) == zeros(ComplexF64, 2, 2)
+    @test sys.n_drives == 2
+    @test sys.levels == 2
+    u = [0.4, -0.6]
+    @test sys.H(u, 0.0) ≈ 0.4 * H_x - 0.6 * H_y
+
+    # Scalar/tuple bounds both accepted
+    sys_t = QuantumSystem([LinearDrive(H_x, 1)], [(-0.5, 0.5)])
+    @test sys_t.drive_bounds == [(-0.5, 0.5)]
+    @test sys_t.n_drives == 1
+
+    # Empty drive vector is rejected
+    @test_throws AssertionError QuantumSystem(LinearDrive[], [1.0])
+end
+
+@testitem "QuantumSystem structured (non-matrix) drift operator" begin
+    using Piccolo
+    using SparseArrays
+    using LinearAlgebra
+
+    # A Piccolissimo-style structured drift operator: not an AbstractMatrix,
+    # but convertible via Base.Matrix and sized via Base.size.
+    struct DiagOp
+        d::Vector{ComplexF64}
+    end
+    Base.Matrix(op::DiagOp) = diagm(op.d)
+    Base.size(op::DiagOp) = (length(op.d), length(op.d))
+    Base.size(op::DiagOp, d::Integer) = 1 <= d <= 2 ? length(op.d) : 1
+
+    H_drift_op = DiagOp(ComplexF64[0.0, 1.0, 2.0])
+    σx_3 = sparse(ComplexF64[0 1 0; 1 0 1; 0 1 0] / sqrt(2))
+    drives = [LinearDrive(σx_3, 1)]
+
+    sys = QuantumSystem(H_drift_op, drives, [1.0])
+    @test sys isa QuantumSystem
+    # The structured operator is stored as-is (not sparsified away)
+    @test sys.H_drift === H_drift_op
+    @test sys.levels == 3
+    @test sys.n_drives == 1
+    @test get_drift(sys) ≈ Matrix(H_drift_op)
+
+    # H(u, t) closure materializes from the operator
+    u = [0.25]
+    @test sys.H(u, 0.0) ≈ Matrix(H_drift_op) + 0.25 * σx_3
+
+    # G(u, t) is the isomorphic generator of the same Hamiltonian
+    @test sys.G(u, 0.0) ≈ Piccolo.Isomorphisms.G(Matrix(H_drift_op) + 0.25 * σx_3)
+
+    # LinearDrive index outside the control dimension is rejected
+    @test_throws AssertionError QuantumSystem(H_drift_op, [LinearDrive(σx_3, 2)], [1.0])
+
+    # NonlinearDrive Jacobian validation runs against n_drives + globals
+    nd_bad = NonlinearDrive(σx_3, u -> u[1]^2, (u, j) -> 3u[1])
+    @test_throws AssertionError QuantumSystem(H_drift_op, [nd_bad], [1.0])
+
+    # No drives: H/G are the drift alone
+    sys0 = QuantumSystem(H_drift_op, AbstractDrive[], Float64[])
+    @test sys0.n_drives == 0
+    @test sys0.H(rand(0), 0.7) ≈ Matrix(H_drift_op)
+    @test sys0.G(rand(0), 0.7) ≈ Piccolo.Isomorphisms.G(Matrix(H_drift_op))
+end
+
+@testitem "QuantumSystem function-constructor bound and hermiticity branches" begin
+    using Piccolo
+    using LinearAlgebra
+
+    # Asymmetric tuple bounds: the Hermiticity probe evaluates at the
+    # interval midpoint (b[1] + b[2]) / 2, not at 0.0.
+    H_mid = (u, t) -> PAULIS.Z + u[1] * PAULIS.X
+    sys = QuantumSystem(H_mid, [(-0.5, 1.5)])
+    @test sys.drive_bounds == [(-0.5, 1.5)]
+    @test sys.n_drives == 1
+
+    # Non-Hermitian at the probe point but hermitian=false opts out
+    H_nh = (u, t) -> PAULIS.Z + u[1] * (PAULIS.X + im * PAULIS.Y)
+    sys_nh = QuantumSystem(H_nh, [1.0]; hermitian = false)
+    @test sys_nh.hermitian == false
+    @test sys_nh.levels == 2
+
+    # The same non-Hermitian Hamiltonian fails the default check. Asymmetric
+    # bounds are required: the control probe evaluates at the midpoint
+    # (lo + hi) / 2, which is nonzero here.
+    @test_throws AssertionError QuantumSystem(H_nh, [(-0.5, 1.5)])
+
+    # global_params are float-converted (Ints become Float64)
+    sys_gp = QuantumSystem((u, t) -> u[1] * PAULIS.X, [1.0]; global_params = (δ = 1, Ω = 2))
+    @test sys_gp.global_params isa NamedTuple
+    @test all(v -> v isa Float64, values(sys_gp.global_params))
+    @test sys_gp.global_params == (δ = 1.0, Ω = 2.0)
 end


### PR DESCRIPTION
Part of the coverage campaign (#294; cluster A+B merged as #295/#296). 40 new testitems + 2 extended, 1653 insertions across 8 files. All touched-file suites green in the dev env (per-file numbers in the work log).

**Covered:** the problem-display machinery (inspect.jl's bound/global/goal/integrator/objective/constraint classification, all 6 trajectory types' goal summaries, free-phase helpers — 71 lines), Rollouts' constructor variants + all three rollout_fidelity interpolation kinds + the Magnus cross-check (64 lines), QuantumSystem's typed-drift/structured-op/Hermiticity/global-coercion branches (45), the template helpers' full surface incl. calibration pinning and complex-norm (26+22), pulse edge branches (20), PiccoloMakieExt's animate/sweep/LivePulsePlotCallback paths (30), and PiccoloQuantumToolboxExt end-to-end (34) — QuantumToolbox v0.47.3 resolves cleanly, contra the #259 experience; the ext tests are live.

**Accepted gaps (documented in the work log):** the two Piccolissimo-gated interior-bounds branches (unreachable in this repo), the free-phase objective J-selection branches (construction errors without a Piccolissimo integrator), two display dead-paths that ARE bugs (filed), one shadowed dead guard in quantum_systems.

**Bugs found (filed separately):** global-constraint display always shows ':free' for pinned/bounded globals (the type-name matching can never match — they're constructor functions, not types); `_fidelity_at(::KetTrajectory)` MethodErrors silently → no phased fidelity ever displays for ket problems; `animate_bloch` is FULLY broken (FieldError every frame — reads a field the QuantumToolbox.Bloch doesn't have); two guards call a nonexistent `raise()` → UndefVarError instead of ArgumentError.