### PR TITLE
fix(display): global pin/bound status, ket phased fidelity, animate_bloch, raise() guards (#299)

### DIFF
--- a/ext/PiccoloQuantumToolboxExt.jl
+++ b/ext/PiccoloQuantumToolboxExt.jl
@@ -157,7 +157,7 @@ function QuantumToolbox.plot_bloch(
         elseif state_type == :density
             iso_vec_to_bloch(s, subspace)
         else
-            raise(ArgumentError("State type must be :ket or :density."))
+            throw(ArgumentError("State type must be :ket or :density."))
         end
     end
 
@@ -202,7 +202,7 @@ function Piccolo.plot_bloch!(fig::Figure, traj::NamedTrajectory, idx::Int; kwarg
         state_name = fig.attributes[:state_name][]
         subspace = fig.attributes[:subspace][]
         v = iso_to_bloch(traj[idx][state_name], subspace)
-        fig.attributes[:vec] = [bloch_arrow(v, b.b.vector_tiplength)]
+        fig.attributes[:vec] = [bloch_arrow(v, b.vector_tiplength)]
     end
 
     return fig
@@ -307,7 +307,7 @@ function QuantumToolbox.plot_wigner(
     elseif state_type == :density
         QuantumObject(iso_vec_to_density(traj[idx][state_name]))
     else
-        raise(ArgumentError("State type must be :ket or :density."))
+        throw(ArgumentError("State type must be :ket or :density."))
     end
 
     fig, ax, hm = QuantumToolbox.plot_wigner(state; library = Val(:Makie), kwargs...)
@@ -338,7 +338,7 @@ function Piccolo.plot_wigner!(fig::Figure, traj::NamedTrajectory, idx::Int)
     elseif state_type == :density
         QuantumObject(iso_vec_to_density(traj[idx][state_name]))
     else
-        raise(ArgumentError("State type must be :ket or :density."))
+        throw(ArgumentError("State type must be :ket or :density."))
     end
     W = transpose(wigner(state, hm[1][], hm[2][]))
     hm[3][] = W
@@ -389,11 +389,15 @@ end
     @test haskey(fig.attributes, :vec)
     v_before = copy(fig.attributes[:vec][])
 
-    # KNOWN BUG (reported): plot_bloch! reads `b.b.vector_tiplength` from the
-    # saved QuantumToolbox.Bloch, which has no field `b` — the update path
-    # throws FieldError before moving the arrow. We lock in the no-crash-silently
-    # contract: the call throws (rather than silently returning a stale figure).
-    @test_throws Exception Piccolo.plot_bloch!(fig, traj, 6)
+    # plot_bloch! moves the saved arrow to knot 6 — reading the tip-length
+    # styling directly off the stored QuantumToolbox.Bloch (which exposes
+    # vector_tiplength as a field). The result must match the vector a fresh
+    # index=6 figure saves, and differ from the knot-1 arrow.
+    fig6 = QuantumToolbox.plot_bloch(traj; index = 6)
+    @test Piccolo.plot_bloch!(fig, traj, 6) === fig
+    v_after = fig.attributes[:vec][]
+    @test collect(v_after[1]) ≈ collect(fig6.attributes[:vec][][1])
+    @test collect(v_after[1]) != collect(v_before[1])
 
     # A figure without animation attributes is a no-op that returns the figure
     fig_plain = QuantumToolbox.plot_bloch(traj)
@@ -405,7 +409,7 @@ end
     @test_throws AssertionError Piccolo.plot_bloch!(fig, traj, 7)
 end
 
-@testitem "animate_bloch currently throws (documented bug)" begin
+@testitem "animate_bloch records an mp4" begin
     using QuantumToolbox
     using NamedTrajectories
     using Piccolo
@@ -415,10 +419,14 @@ end
     ψ̃ = hcat([ket_to_iso(ComplexF64[cos(θ), sin(θ)]) for θ in θs]...)
     traj = NamedTrajectory((ψ̃ = ψ̃, Δt = fill(0.1, 5)))
 
-    # KNOWN BUG (reported): animate_bloch's per-frame update calls plot_bloch!,
-    # which reads `b.b.vector_tiplength` off a QuantumToolbox.Bloch that has no
-    # field `b`. Until that is fixed, every animation frame throws FieldError.
-    @test_throws Exception Piccolo.animate_bloch(traj; mode = :record, fps = 4)
+    # The per-frame update reads the tip-length styling off the stored Bloch
+    # (no field `b`), so every frame renders and the animation records cleanly.
+    out = tempname() * ".mp4"
+    fig = Piccolo.animate_bloch(traj; mode = :record, fps = 4, filename = out)
+    @test fig isa Figure
+    @test isfile(out)
+    @test filesize(out) > 0
+    rm(out; force = true)
 end
 
 @testitem "plot_bloch argument guards" begin
@@ -430,10 +438,8 @@ end
     ψ̃ = hcat(ket_to_iso(ComplexF64[1.0, 0.0]), ket_to_iso(ComplexF64[0.0, 1.0]))
     traj = NamedTrajectory((ψ̃ = ψ̃, Δt = [1.0, 1.0]))
 
-    # KNOWN BUG (reported): the unknown-state_type guard calls `raise(...)`,
-    # which is undefined in the extension — the guard throws UndefVarError
-    # instead of the intended ArgumentError. The branch is still exercised.
-    @test_throws Exception QuantumToolbox.plot_bloch(traj; state_type = :bogus)
+    # The unknown-state_type guard throws the intended ArgumentError
+    @test_throws ArgumentError QuantumToolbox.plot_bloch(traj; state_type = :bogus)
 
     # Index outside the knot range is rejected
     @test_throws AssertionError QuantumToolbox.plot_bloch(traj; index = 0)
@@ -477,9 +483,8 @@ end
     ψ̃ = hcat(ket_to_iso(coherent(10, 0.5).data))
     traj = NamedTrajectory((ψ̃ = ψ̃, Δt = [1.0]))
 
-    # KNOWN BUG (reported): same undefined `raise(...)` guard as plot_bloch —
-    # UndefVarError instead of ArgumentError. The branch is still exercised.
-    @test_throws Exception QuantumToolbox.plot_wigner(
+    # The unknown-state_type guard throws the intended ArgumentError
+    @test_throws ArgumentError QuantumToolbox.plot_wigner(
         traj,
         1;
         state_name = :ψ̃,

--- a/src/control/display/inspect.jl
+++ b/src/control/display/inspect.jl
@@ -317,19 +317,20 @@ function _global_infos(traj, constraints)
     out = GlobalInfo[]
     isempty(traj.global_components) && return out
 
-    # Build a map: global name → constraint involvement
+    # Build a map: global name → constraint involvement. In DirectTrajOpt,
+    # `GlobalEqualityConstraint`/`GlobalBoundsConstraint` are constructor
+    # *functions* that return plain EqualityConstraint/BoundsConstraint structs
+    # flagged with `is_global = true` — so global constraints must be detected
+    # structurally (type + flag), never by typename.
     pinned_names = Set{Symbol}()
-    bounded_names = Dict{Symbol,Any}()  # name → bounds tuple
+    bounded_names = Dict{Symbol,Any}()  # name → bounds spec
     for c in constraints
-        # GlobalEqualityConstraint pins a value
-        if _typename(c) == "GlobalEqualityConstraint" && hasproperty(c, :name)
-            push!(pinned_names, c.name)
-        end
-        # GlobalBoundsConstraint adds bounds
-        if _typename(c) == "GlobalBoundsConstraint" && hasproperty(c, :name)
-            if hasproperty(c, :bounds)
-                bounded_names[c.name] = c.bounds
-            end
+        # A global EqualityConstraint pins a value (e.g. a calibration target)
+        if c isa EqualityConstraint && c.is_global
+            push!(pinned_names, c.var_names)
+            # A global BoundsConstraint adds bounds
+        elseif c isa BoundsConstraint && c.is_global
+            bounded_names[c.var_names] = c.bounds_values
         end
     end
 
@@ -683,13 +684,27 @@ end
 
 function _fidelity_at(qtraj::KetTrajectory, traj, θ)
     # subsystem_levels for the phase rotation aren't stored on the qtraj; we
-    # need them to build the rotation. Best-effort: try to infer from system.
+    # need them to build the rotation. Best-effort: infer from the system.
     sys = QuantumControlProblems.get_system(qtraj)
-    levels = hasproperty(sys, :levels) ? sys.levels : nothing
+    levels = _subsystem_levels_for_phase(sys)
     levels === nothing && return nothing
     ψ̃ = traj[state_name(qtraj)][:, end]
     ψ_goal_phased = _phased_ket_goal(qtraj.goal, θ, levels)
     return Float64(QuantumObjectives.ket_fidelity_loss(ψ̃, ψ_goal_phased))
+end
+
+# `_phased_ket_goal` expects one level count per subsystem. A plain
+# QuantumSystem stores a scalar `levels::Int` (a single subsystem — wrap it);
+# a CompositeQuantumSystem stores `subsystem_levels::Vector{Int}` (its
+# `levels` field is the *total* dimension and must not be wrapped).
+function _subsystem_levels_for_phase(sys)
+    if hasproperty(sys, :subsystem_levels) &&
+       sys.subsystem_levels isa AbstractVector{<:Integer}
+        return collect(Int, sys.subsystem_levels)
+    elseif hasproperty(sys, :levels) && sys.levels isa Integer
+        return [Int(sys.levels)]
+    end
+    return nothing
 end
 
 _fidelity_at(::AbstractQuantumTrajectory, _, _) = nothing

--- a/src/control/display/show.jl
+++ b/src/control/display/show.jl
@@ -417,6 +417,7 @@ end
 @testitem "inspect.jl system/trajectory helper branches" begin
     using Piccolo
     using NamedTrajectories
+    using DirectTrajOpt
 
     PD = Piccolo.Control.ProblemDisplay
 
@@ -492,6 +493,58 @@ end
     )
     # x contributes dim 2 × N 4 = 8; u contributes 1 × 4 = 4; globals 1
     @test PD._count_bounded_vars(traj_count) == 13
+
+    # -- _global_infos: pin/bound status detected structurally --
+    # GlobalEqualityConstraint/GlobalBoundsConstraint are constructor functions
+    # in DirectTrajOpt: they return plain EqualityConstraint/BoundsConstraint
+    # structs with is_global = true, so detection keys on type + flag.
+    traj_glob = NamedTrajectory(
+        (u = randn(1, 5), Δt = fill(0.1, 5));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.7, 0.3],
+        global_components = (δ = 1:1, ω = 2:2),
+    )
+    cons = AbstractConstraint[
+        BoundsConstraint(:u, collect(1:5), 1.0),     # non-global: must be ignored
+        GlobalBoundsConstraint(:ω, ([-0.2], [0.8])), # bounded global (asymmetric)
+    ]
+    fix_global_variable!(cons, :δ, [0.7])            # pinned calibration target
+    infos = PD._global_infos(traj_glob, cons)
+    by_name = Dict(g.name => g for g in infos)
+    @test by_name[:δ].status === :pinned
+    @test by_name[:δ].bound_repr == "pinned"
+    @test by_name[:ω].status === :free
+    @test by_name[:ω].bound_repr == "[[-0.2], [0.8]]"
+
+    # A free-phase global with its usual ±2π bounds reports :free_phase
+    traj_phi = NamedTrajectory(
+        (u = randn(1, 5), Δt = fill(0.1, 5));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.0, 2π],
+        global_components = (φ_1 = 1:1, φ_2 = 2:2),
+    )
+    cons_phi = AbstractConstraint[
+        GlobalBoundsConstraint(:φ_1, ([-2π], [2π])),
+        GlobalBoundsConstraint(:φ_2, ([-2π], [2π])),
+    ]
+    phi_infos = PD._global_infos(traj_phi, cons_phi)
+    phi_by_name = Dict(g.name => g for g in phi_infos)
+    @test phi_by_name[:φ_1].status === :free_phase
+    @test phi_by_name[:φ_1].bound_repr == "±2π"
+
+    # A global with no constraints at all stays :free with an em dash
+    traj_free = NamedTrajectory(
+        (u = randn(1, 5), Δt = fill(0.1, 5));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.5],
+        global_components = (δ = 1:1,),
+    )
+    g_free = only(PD._global_infos(traj_free, AbstractConstraint[]))
+    @test g_free.status === :free
+    @test g_free.bound_repr == "—"
 end
 
 @testitem "inspect.jl goal summaries and integrator rendering" begin
@@ -737,19 +790,26 @@ end
     )
     @test PD._fidelity_at(qtraj_u, traj, [0.3]) === nothing
 
-    # _fidelity_at on a KetTrajectory: QuantumSystem.levels is a scalar Int, so
-    # _phased_ket_goal has no matching method — the MethodError is caught by
-    # _fidelity_with_stored_phases (which then reports F_with_phase = nothing).
+    # _fidelity_at on a KetTrajectory: the system's scalar `levels::Int` is
+    # wrapped as [levels] (one subsystem), so _phased_ket_goal gets the
+    # per-subsystem vector it expects and the phased goal is actually built
+    # (previously this MethodError'd and _fidelity_with_stored_phases silently
+    # swallowed it, reporting F_with_phase = nothing for every ket problem).
     qtraj_k = KetTrajectory(sys, pulse, ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0])
+    ψ_end = ComplexF64[1.0, 1.0] / √2
     traj_ket = NamedTrajectory(
-        (ψ̃ = randn(4, 5), u = randn(1, 5), Δt = fill(0.25, 5));
+        (ψ̃ = hcat([ket_to_iso(ψ_end) for _ = 1:5]...), u = randn(1, 5), Δt = fill(0.25, 5));
         controls = :u,
         timestep = :Δt,
         global_data = [0.3],
         global_components = (φ_1 = 1:1,),
     )
-    @test_throws MethodError PD._fidelity_at(qtraj_k, traj_ket, [0.3])
-    @test PD._fidelity_with_stored_phases(qtraj_k, traj_ket) === nothing
+    F_ket = PD._fidelity_at(qtraj_k, traj_ket, [0.3])
+    @test F_ket isa Float64
+    @test F_ket ≈ abs2(ψ_end[2])   # phased goal is e^{iφ}|1⟩ → F = |⟨1|ψ_end⟩|²
+    F_ket_phase = PD._fidelity_with_stored_phases(qtraj_k, traj_ket)
+    @test F_ket_phase isa Float64
+    @test F_ket_phase ≈ F_ket      # same φ_1 = 0.3 read out of global_data
 
     # _fidelity_with_stored_phases: no φ_ globals → nothing
     traj_nophi = NamedTrajectory(
@@ -901,7 +961,10 @@ end
     @test occursin("free_phase", s)
 
     # Global bounds on φ_1 surface as a ±2π row in the inspection
-    @test any(g -> g.name === :φ_1, ins.globals)
+    φ_rows = filter(g -> g.name === :φ_1, ins.globals)
+    @test length(φ_rows) == 1
+    @test φ_rows[1].status === :free_phase
+    @test φ_rows[1].bound_repr == "±2π"
 end
 
 @testitem "_maybe_display respects the display tier" begin


### PR DESCRIPTION
Closes #299 — the display-layer honesty fixes for 2.0.1. All four verified by the coverage campaign (#298):

1. **Global pin/bound status never displayed** — `_global_infos` matched type *names* that are constructor functions in DirectTrajOpt; now keys on `c isa EqualityConstraint && c.is_global` (pinned) / `c isa BoundsConstraint && c.is_global` (bounded). Calibration pins and global bounds render as intended for the first time.
2. **Ket phased fidelity silently MethodErrored** — `sys.levels` (Int) passed where a vector was required, swallowed by the catch; new `_subsystem_levels_for_phase` helper handles plain (wrap) vs Composite (its `levels` is total-dim — must not wrap) systems. Ket problems now get the `F (with φ)` line.
3. **`animate_bloch` fully broken** — read `b.b.vector_tiplength` off a Bloch with no field `b`; the fields are direct. Every frame FieldErrored. Fixed; the testitem now records a real mp4 instead of asserting the throw.
4. **Three `raise()` guards** (found a third beyond the issue's two) — `raise` is not a Julia function; all now `throw(ArgumentError(...))`, tests tightened to `@test_throws ArgumentError`.

203/203 display/ext testitems green.