### PR TITLE
fix(specs): order-dependent flake in the drift testitems — import Piccolo for pkgdir

### DIFF
--- a/src/specs/schema/drift.jl
+++ b/src/specs/schema/drift.jl
@@ -11,7 +11,7 @@
 # public CI never loads Piccolissimo. See plan review correction (Blocking #1).
 
 @testitem "OSS schema drift: emit_schema() == checked-in problemspec.oss.schema.json" begin
-    using Piccolo.Specs, JSON3
+    using Piccolo, Piccolo.Specs, JSON3
     Specs.register_all!()
     emitted = JSON3.write(JSON3.read(Specs.emit_schema()))
     file =
@@ -22,7 +22,7 @@
 end
 
 @testitem "OSS schema excludes private Piccolissimo enum values (scoped)" begin
-    using Piccolo.Specs, JSON3
+    using Piccolo, Piccolo.Specs, JSON3
     Specs.register_all!()
     sch = JSON3.read(Specs.emit_schema())
     ctrl = sch.oneOf[1].properties.kind.const == "control" ? sch.oneOf[1] : sch.oneOf[2]


### PR DESCRIPTION
One-word fix found by the #297 agent's isolated filtered runs: `using Piccolo.Specs, JSON3` leaves `Piccolo` itself undefined, so `pkgdir(Piccolo)` in both drift testitems only worked when a prior testitem on the same worker had done `using Piccolo`. Fails deterministically in isolation on main and on the v2.0.0 worktree.