### PR TITLE
release: v2.0.2 — compat: admit DirectTrajOpt 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]
@@ -45,7 +45,7 @@ PiccoloQuantumToolboxExt = ["QuantumToolbox", "Makie"]
 Aqua = "0.8"
 CairoMakie = "0.15"
 DataInterpolations = "8.9"
-DirectTrajOpt = "0.9.5"
+DirectTrajOpt = "0.9.5, 0.10"
 Distributions = "0.25"
 ExponentialAction = "0.2"
 ForwardDiff = "1.3"


### PR DESCRIPTION
One-line compat widening, unblocking Piccolissimo 0.4.0's Manifest resolution (its chain: Piccolo pinned-tree's `DirectTrajOpt = "0.9.5"` vs Piccolissimo's requirement of 0.10 → unsatisfiable). API-compatible: SolveStats is additive; the Δt-weighting is DTO's behaviour change, experienced on DTO update regardless of Piccolo.

On merge: tag v2.0.2 + `@JuliaRegistrator register`.