### PR TITLE
docs: Performance guidance section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ This package is registered! To install enter the Julia REPL, type `]` to enter p
 pkg> add Piccolo
 ```
 
+### Performance guidance
+
+The open stack solves direct-collocation problems with **dense assembled** gradients —
+`BilinearIntegrator` for zero-order holds (spline constraints via `DerivativeIntegrator`) —
+with **Ipopt** as the default NLP solver and **MadNLP** as an alternative. Dense paths are
+fine for small-to-medium problems; on stiff or large ones keep timesteps short and verify
+rollouts independently.
+
+The **matrix-free / Altissimo surface** — NewtonCG solves driven by JVP/VJP/HVP products
+that never form ∂Φ, the `matrix_free` flag on `HermitianExponentialIntegrator`, the
+spline/Magnus and GPU integrator family, and the opt-in exact inequality HVP — lives in the
+**proprietary Piccolissimo stack**, not in this repository (see
+[docs.harmoniqs.co](https://docs.harmoniqs.co) for that surface).
+
+**2.0 migration:** the `subsystem_levels` kwarg was removed from `SmoothPulseProblem`;
+free-phase now derives levels from the goal — wrap gate targets in
+`EmbeddedOperator(gate, sys)`.
+
 <!--## Star History-->
 
 <!--[![Star History Chart](https://api.star-history.com/svg?repos=harmoniqs/piccolo.jl,harmoniqs/namedtrajectories.jl,harmoniqs/directtrajopt.jl&type=Date)](https://www.star-history.com/#harmoniqs/piccolo.jl&harmoniqs/namedtrajectories.jl&harmoniqs/directtrajopt.jl&Date)-->


### PR DESCRIPTION
Closes #319. Docs-only chore (no package code).

## What changed
- **`README.md`** — new **Performance guidance** section:
  - Open-stack summary: direct collocation with **dense assembled** gradients (`BilinearIntegrator` for zero-order holds, `DerivativeIntegrator` for spline constraints), **Ipopt** default / **MadNLP** alternative; dense paths fine for small-to-medium problems.
  - One pointer sentence stating exactly that the **matrix-free / Altissimo surface** (NewtonCG JVP/VJP/HVP without forming ∂Φ, the `matrix_free` flag on `HermitianExponentialIntegrator`, spline/Magnus + GPU integrators, opt-in exact inequality HVP) lives in the **proprietary Piccolissimo stack**, not this repo — linked to docs.harmoniqs.co, no entitlement mechanics.
  - **2.0 migration note:** `subsystem_levels` kwarg removed from `SmoothPulseProblem` → wrap gate targets in `EmbeddedOperator(gate, sys)`.

No invented benchmarks; README only (repo root has no CONTEXT.md; `docs/` is the Documenter site).