### PR TITLE
Fix  binding under NamedTrajectories >= 0.9.3 co-resolve (#323)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -7,7 +7,12 @@ using TestItems
 
 using DirectTrajOpt: AbstractIntermediateCallback
 using NamedTrajectories: update!
-using Piccolo: AbstractQuantumTrajectory, extract_pulse, plot_pulse
+using Piccolo: AbstractQuantumTrajectory, duration, extract_pulse, plot_pulse
+
+# `duration` bound explicitly from Piccolo: with NamedTrajectories >= 0.9.3
+# co-resolved (`using NamedTrajectories` above), TimeWarp also exports
+# `duration` and the bare name does not resolve here (#323). Piccolo.duration
+# is the Quantum.Pulses function — the binding every NT version provides.
 
 # Animation implementations - extend Piccolo stubs.
 # Docstrings live on the stubs in `src/visualizations/animations.jl`.

--- a/ext/PiccoloQuantumToolboxExt.jl
+++ b/ext/PiccoloQuantumToolboxExt.jl
@@ -6,6 +6,12 @@ using Makie
 using NamedTrajectories
 using LinearAlgebra
 
+# `duration` bound explicitly from Piccolo: with NamedTrajectories >= 0.9.3
+# co-resolved (`using NamedTrajectories` above), TimeWarp also exports
+# `duration` and the bare name does not resolve here (#323). Piccolo.duration
+# is the Quantum.Pulses function — the binding every NT version provides.
+using Piccolo: duration
+
 using TestItems
 
 # `animate_bloch`, `animate_wigner`, `plot_bloch!`, and `plot_wigner!` extend Piccolo

--- a/src/Piccolo.jl
+++ b/src/Piccolo.jl
@@ -11,6 +11,13 @@ using Reexport
 include("quantum/_quantum.jl")
 @reexport using .Quantum
 
+# Same collision one level up (#323): NT >= 0.9.3 exports `duration` via
+# TimeWarp and NT is reexported above, so `duration` was ambiguous in this
+# namespace and unbound at top level (`using Piccolo; duration` →
+# UndefVarError). Bind explicitly from the defining module so `using Piccolo`
+# keeps exposing the Quantum.Pulses `duration` in every environment.
+using .Quantum.Pulses: duration
+
 # Optimal control: objectives, constraints, problem templates
 include("control/_control.jl")
 @reexport using .Control

--- a/src/quantum/_quantum.jl
+++ b/src/quantum/_quantum.jl
@@ -31,6 +31,13 @@ include("primitives/isomorphisms.jl")
 include("primitives/pulses.jl")
 @reexport using .Pulses
 
+# `duration` must resolve to the Pulses function in this namespace: with
+# NamedTrajectories >= 0.9.3 co-resolved (`using NamedTrajectories` above),
+# TimeWarp also exports `duration`, which left the name ambiguous here —
+# UndefVarError at `Quantum.duration` and at downstream `import ..Quantum:
+# duration` sites (#323). Bind explicitly from the defining module.
+using .Pulses: duration
+
 # Object utils (depends on gates)
 include("object_utils.jl")
 @reexport using .QuantumObjectUtils

--- a/src/quantum/trajectories/extract_pulse.jl
+++ b/src/quantum/trajectories/extract_pulse.jl
@@ -77,6 +77,9 @@ end
 @testitem "extract_pulse with ZeroOrderPulse - UnitaryTrajectory" begin
     using LinearAlgebra
     using NamedTrajectories
+    # Explicit bind: NT >= 0.9.3 also exports `duration` (TimeWarp), so the bare
+    # name does not resolve in this dual-using namespace (#323).
+    using Piccolo.Quantum.Pulses: duration
 
     system = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
 

--- a/src/quantum/trajectories/named_trajectory_conversion.jl
+++ b/src/quantum/trajectories/named_trajectory_conversion.jl
@@ -735,6 +735,9 @@ end
 @testitem "UnitaryTrajectory" begin
     using LinearAlgebra
     using NamedTrajectories
+    # Explicit bind: NT >= 0.9.3 also exports `duration` (TimeWarp), so the bare
+    # name does not resolve in this dual-using namespace (#323).
+    using Piccolo.Quantum.Pulses: duration
 
     # Simple 2-level system
     system = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
@@ -796,6 +799,9 @@ end
 @testitem "KetTrajectory" begin
     using LinearAlgebra
     using NamedTrajectories
+    # Explicit bind: NT >= 0.9.3 also exports `duration` (TimeWarp), so the bare
+    # name does not resolve in this dual-using namespace (#323).
+    using Piccolo.Quantum.Pulses: duration
 
     # Simple 2-level system
     system = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
@@ -854,6 +860,9 @@ end
 @testitem "DensityTrajectory" begin
     using LinearAlgebra
     using NamedTrajectories
+    # Explicit bind: NT >= 0.9.3 also exports `duration` (TimeWarp), so the bare
+    # name does not resolve in this dual-using namespace (#323).
+    using Piccolo.Quantum.Pulses: duration
 
     # Simple 2-level open system
     L = ComplexF64[0.1 0.0; 0.0 0.0]  # Decay operator

--- a/test/test_duration_reexport_binding.jl
+++ b/test/test_duration_reexport_binding.jl
@@ -1,0 +1,45 @@
+# ============================================================================ #
+# #323 — `duration` binding under a NamedTrajectories ≥ 0.9.3 co-resolve
+#
+# NT 0.9.3 added the TimeWarp module, which exports `duration`. Piccolo
+# reexports both NamedTrajectories and Quantum (→ Quantum.Pulses, the defining
+# module of `duration`), so with NT ≥ 0.9.3 in the environment the name used to
+# resolve as ambiguous in Piccolo's own namespace — UndefVarError at top level,
+# at `Piccolo.duration`, and at `Piccolo.Quantum.duration`, instead of binding
+# to the Pulses function. Regression contract: `duration` binds to
+# `Quantum.Pulses.duration` — the exact binding a non-colliding environment
+# (NT < 0.9.3) has always provided — and is NOT the TimeWarp function.
+#
+# The test item reproduces the issue's namespace faithfully: `using Piccolo`
+# only. `import NamedTrajectories as NT` deliberately binds just the module
+# name — a plain `using NamedTrajectories` would re-create the two-package
+# export collision in this module, where bare `duration` is inherently
+# ambiguous (both bindings are exported; consumers bind from the defining
+# module, as harmoniqs/Strumento.jl#19 does).
+# ============================================================================ #
+
+@testitem "duration binds to Quantum.Pulses with NamedTrajectories >= 0.9.3 co-resolved (#323)" begin
+    using Piccolo
+    import NamedTrajectories as NT
+
+    # Collision precondition — the suite env must actually co-resolve NT ≥ 0.9.3
+    # whose TimeWarp exports `duration`. If a resolve ever pins NT below 0.9.3
+    # these fail loudly, so this test cannot pass vacuously.
+    nt_version = pkgversion(NT)
+    @test nt_version >= v"0.9.3"
+    @test :duration in names(NT)
+
+    # Top-level binding (the issue's repro surface: `using Piccolo; duration`).
+    @test @isdefined(duration)
+    @test duration === Piccolo.Quantum.Pulses.duration
+
+    # The package's own namespaces must resolve the name too.
+    @test isdefined(Piccolo, :duration)
+    @test Piccolo.duration === Piccolo.Quantum.Pulses.duration
+    @test isdefined(Piccolo.Quantum, :duration)
+    @test Piccolo.Quantum.duration === Piccolo.Quantum.Pulses.duration
+
+    # Explicit non-collision contract: the binding is the Pulses function
+    # object, never the TimeWarp one.
+    @test Piccolo.duration !== NT.TimeWarp.duration
+end


### PR DESCRIPTION
Closes #323.

## Problem

NT 0.9.3+ (TimeWarp) exports `duration`; Piccolo reexports both NamedTrajectories and Quantum (→ Quantum.Pulses, the defining module). With NT ≥ 0.9.3 co-resolved, `duration` resolves as ambiguous in Piccolo's namespace: UndefVarError at top level (`using Piccolo; duration`), at `Piccolo.duration`, and at `Piccolo.Quantum.duration`. Precompile also warns `Imported binding Quantum.duration was undeclared at import time` (the `import ..Quantum: duration` in SplineIntegrators and `using Piccolo: duration` in QuantumObjectPlots bind through the ambiguity).

## Approach

Bind `duration` explicitly from the defining module at both namespaces where the ambiguity is observable:

- `Quantum`: `using .Pulses: duration` (after the `.Pulses` reexport)
- `Piccolo` top: `using .Quantum.Pulses: duration` (after the `.Quantum` reexport)

This is the resolution pattern already used in-repo (`_quantum_trajectories.jl` binds `using ..Pulses: duration` where NT is co-visible) and by consumers (harmoniqs/Strumento.jl#19). Export coordination with NamedTrajectories was rejected: it would require an NT-side breaking change (un-export) or a dependency inversion (NT cannot import from Piccolo). Behavior in non-colliding environments (NT < 0.9.3) is byte-identical: `Piccolo.duration` was and remains the `Quantum.Pulses` function object.

## Evidence

RED (this branch, first commit, NT 0.9.4 pinned in a fresh env): `@isdefined(duration)` fails with the ambiguity note "Also exported by NamedTrajectories"; the binding assertion errors UndefVarError. Fix commit turns the same assertions green; full suite green in CI.