### PR TITLE
chore: version 2.1.0 — #323 registration rides a minor (AutoMerge: patch may not narrow the julia range)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "2.0.3"
+version = "2.1.0"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]


### PR DESCRIPTION
Follow-up to #324 / #323.

The 2.0.3 registration (JuliaRegistries/General#166662) was blocked by AutoMerge: a **patch release may not narrow the supported Julia range**, and the registered tree carries main's julia floor raise (released 2.0.2 is `1.10.0 - 1`; main has required `1.12` since the 3b slice). Compat narrowing rides a minor, so the registration becomes **2.1.0**.

Version-only change; the fix content is unchanged from the merged #324 (squash 599983c9). After merge, Registrator is re-invoked on the new merge commit and updates the open General PR.