### PR TITLE
feat(321): HermitianExponentialIntegrator warp column — derived-Δt dynamics with exact duration sensitivities (TR Phase 1b)

### DIFF
--- a/src/control/integrators_exponential/_exponential_integrators.jl
+++ b/src/control/integrators_exponential/_exponential_integrators.jl
@@ -257,6 +257,7 @@ end
 
 include("daleckii_krein.jl")
 include("hermitian_exponential_integrator_type.jl")
+include("warp_plumbing.jl")   # derived-Δt (time-warp) scaffolding — Piccolo.jl#321
 include("hermitian_exponential_integrator_unitary.jl")
 include("hermitian_exponential_integrator_ket.jl")
 include("hermitian_exponential_integrator_multiket.jl")

--- a/src/control/integrators_exponential/hermitian_exponential_integrator_ket.jl
+++ b/src/control/integrators_exponential/hermitian_exponential_integrator_ket.jl
@@ -612,6 +612,10 @@ function get_jacobian_structure(
     ℰ::HermitianExponentialIntegrator{KetTrajectory},
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): packed two-knot windows + the warp
+    # column under a warp; historical structure otherwise.
+    traj.warp !== nothing && return _get_jacobian_structure_warped(ℰ, traj)
+
     N = traj.N
     x_dim = traj.dims[x_name(ℰ)]
     z_dim = traj.dim
@@ -652,6 +656,10 @@ end
     ℰ::HermitianExponentialIntegrator{KetTrajectory},
     traj::NamedTrajectory,
 )
+    # Under a time warp the timestep rows are derived: re-derive them from the
+    # warp so Δtₖ = deltats(warp)[k] is what the defect consumes (no-op warp-free).
+    traj.warp !== nothing && sync_timesteps!(traj)
+
     # Extract globals once (constant across knot points)
     globals = extract_globals(ℰ, traj)
 
@@ -666,6 +674,11 @@ end
     ℰ::HermitianExponentialIntegrator{KetTrajectory},
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): with a warp the packed Jacobian
+    # drops the derived timestep column and gains the EXACT warp-parameter
+    # column (∂cₖ/∂θⱼ = wₖⱼ · ∂cₖ/∂Δtₖ). No warp → historical body, bit-unchanged.
+    traj.warp !== nothing && return _eval_jacobian_warped(ℰ, traj)
+
     N = traj.N
     x_dim = ℰ.x_dim
     z_dim = traj.dim
@@ -712,6 +725,11 @@ end
     traj::NamedTrajectory,
     μ::AbstractVector,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): with a warp the canonical Δt
+    # row/column maps onto the warp-parameter column through the exact chain
+    # rule. No warp → historical body, bit-unchanged.
+    traj.warp !== nothing && return _eval_hessian_of_lagrangian_warped(ℰ, traj, μ)
+
     N = traj.N
     x_dim = ℰ.x_dim
     u_dim = ℰ.u_dim
@@ -1487,4 +1505,145 @@ end
     max_relerr = maximum(relerrs)
     println("  [#204 AC3] Ket forward exp_eigen!-vs-expv max rel err = $max_relerr")
     @test max_relerr < 1e-10
+end
+
+# ============================================================================ #
+# Phase 1b (Piccolo.jl#321): the defect warp column under a time warp
+# (NamedTrajectories#161). Under a warp the timestep rows are derived
+# (Δtₖ = Δtₖ(T)); the packed Jacobian drops the derived Δt column and gains
+# the warp-parameter column with the EXACT chain entries
+# ∂cₖ/∂θⱼ = (∂Δtₖ/∂θⱼ)·∂cₖ/∂Δtₖ — for GlobalScale, wₖ·∂cₖ/∂Δtₖ with
+# wₖ = 1/(N-1), and ∂cₖ/∂Δtₖ = −G(uₖ)·xₖ₊₁ on the satisfied defect.
+# ============================================================================ #
+
+@testitem "HermitianExponentialIntegrator{Ket} defect warp column: exact entries + FD parity" begin
+    using Piccolo
+    using Piccolo.Control.QuantumIntegrators.ExponentialIntegrators:
+        _hermitian_exp_ket, exp_eigen
+    using DirectTrajOpt
+    using NamedTrajectories
+    using TrajectoryIndexingUtils: slice
+    using Random
+    using LinearAlgebra
+    using SparseArrays
+    using Test
+
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X, PAULIS.Y], [1.0, 1.0])
+    N = 6
+    T0 = 1.7
+    Random.seed!(20260831)
+    ψ̃ = randn(4, N)
+    u = 0.3 .* randn(2, N)
+
+    mk_traj(ψ̃) = NamedTrajectory(
+        (ψ̃ = ψ̃, u = u, Δt = fill(T0 / (N - 1), 1, N));  # Δt ignored — derived
+        controls = (:u,),
+        timestep = :Δt,
+        warp = GlobalScale(T0),
+    )
+    traj = mk_traj(ψ̃)
+    ℰ = _hermitian_exp_ket(sys, :ψ̃, :u, traj, Symbol[])
+
+    x_dim = ℰ.x_dim                      # 4 (iso ket)
+    wₖ = 1 / (N - 1)                     # GlobalScale lattice weight
+    T_col = traj.dim * N - traj.dims[:Δt] * N + traj.global_dim + 1  # packed warp base + 1
+
+    # evaluate! reads the DERIVED rows (synced from the warp)
+    δ = zeros(x_dim * (N - 1))
+    evaluate!(δ, ℰ, traj)
+    @test !all(iszero, δ)
+    for k = 1:(N-1)
+        @test δ[((k-1)*x_dim) .+ (1:x_dim)] ≈
+              ψ̃[:, k+1] - exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0)) * ψ̃[:, k]
+    end
+
+    # Jacobian: packed size, and the warp column is the EXACT chain column
+    ∂F = eval_jacobian(ℰ, traj)
+    @test size(∂F) == (x_dim * (N - 1), length(vec(traj)))
+    for k = 1:(N-1)
+        uₖ = u[:, k]
+        Gₖ = sys.G(uₖ, 0.0)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(uₖ, 0.0))
+        dcdΔt = -Gₖ * Φₖ * ψ̃[:, k]                       # ∂cₖ/∂Δtₖ (iso real)
+        @test ∂F[((k-1)*x_dim) .+ (1:x_dim), T_col] ≈ wₖ .* dcdΔt
+    end
+    # the packed width excludes the derived Δt rows and appends the warp param T
+    @test length(vec(traj)) ==
+          (traj.dim - traj.dims[:Δt]) * traj.N + traj.global_dim + n_params(traj.warp)
+
+    # satisfied defect: ∂cₖ/∂Δtₖ = −G(uₖ)·xₖ₊₁ exactly (the issue's form)
+    ψ̃sat = copy(ψ̃)
+    for k = 1:(N-1)
+        ψ̃sat[:, k+1] = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0)) * ψ̃sat[:, k]
+    end
+    traj_sat = mk_traj(ψ̃sat)
+    ℰ_sat = _hermitian_exp_ket(sys, :ψ̃, :u, traj_sat, Symbol[])
+    ∂F_sat = eval_jacobian(ℰ_sat, traj_sat)
+    for k = 1:(N-1)
+        @test ∂F_sat[((k-1)*x_dim) .+ (1:x_dim), T_col] ≈
+              -wₖ .* (sys.G(u[:, k], 0.0) * ψ̃sat[:, k+1])
+    end
+
+    # FD parity of the full Jacobian over the PACKED vector (perturbs T too)
+    function fd_jac(f, z0; h = 1e-6)
+        f0 = f(z0)
+        J = zeros(length(f0), length(z0))
+        for j in eachindex(z0)
+            e = zeros(length(z0))
+            e[j] = h
+            J[:, j] = (f(z0 .+ e) .- f(z0 .- e)) ./ (2h)
+        end
+        return J
+    end
+    f̂ = Z⃗ -> begin
+        unpack!(traj, Z⃗)
+        δ = zeros(x_dim * (N - 1))
+        evaluate!(δ, ℰ, traj)
+        return δ
+    end
+    z0 = collect(vec(traj))
+    ∂F_fd = fd_jac(f̂, z0)
+    @test all(isapprox.(∂F, ∂F_fd; atol = 1e-5, rtol = 1e-5))
+
+    # FD parity of the Hessian of the Lagrangian (exact mode)
+    μ = 0.3 .* collect(1.0:(x_dim*(N-1)))
+    H = eval_hessian_of_lagrangian(ℰ, traj, μ)
+    @test size(H) == (length(vec(traj)), length(vec(traj)))
+    function fd_hess(g, z0; h = 1e-4)
+        n = length(z0)
+        g0 = g(z0)
+        Hm = zeros(n, n)
+        for i = 1:n
+            ei = zeros(n)
+            ei[i] = h
+            Hm[i, i] = (g(z0 .+ ei) - 2g0 + g(z0 .- ei)) / h^2
+            for j = (i+1):n
+                ej = zeros(n)
+                ej[j] = h
+                Hm[i, j] =
+                    Hm[j, i] =
+                        (
+                            g(z0 .+ ei .+ ej) - g(z0 .+ ei .- ej) - g(z0 .- ei .+ ej) +
+                            g(z0 .- ei .- ej)
+                        ) / (4h^2)
+            end
+        end
+        return Hm
+    end
+    ĥ = Z⃗ -> begin
+        unpack!(traj, Z⃗)
+        δ = zeros(x_dim * (N - 1))
+        evaluate!(δ, ℰ, traj)
+        return μ'δ
+    end
+    H_fd = fd_hess(ĥ, z0)
+    @test all(isapprox.(H, triu(H_fd); atol = 2e-3, rtol = 2e-3))
+
+    # structures declare the warp column in packed coordinates
+    S = get_jacobian_structure(ℰ, traj)
+    @test size(S) == (x_dim * (N - 1), length(vec(traj)))
+    @test !iszero(S[slice(1, x_dim), T_col])
+    HS = get_hessian_of_lagrangian_structure(ℰ, traj)
+    @test size(HS) == (length(vec(traj)), length(vec(traj)))
+    @test any(!iszero, HS[T_col, :])
 end

--- a/src/control/integrators_exponential/hermitian_exponential_integrator_multiket.jl
+++ b/src/control/integrators_exponential/hermitian_exponential_integrator_multiket.jl
@@ -449,6 +449,10 @@ function get_jacobian_structure(
     ℰ::HermitianExponentialIntegrator{MultiKetTrajectory},
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): packed two-knot windows + the warp
+    # column under a warp; historical structure otherwise.
+    traj.warp !== nothing && return _get_jacobian_structure_warped(ℰ, traj)
+
     N = traj.N
     x_dim = ℰ.x_dim  # Total constraint dim per knot point (all kets)
     z_dim = traj.dim
@@ -501,6 +505,10 @@ end
     ℰ::HermitianExponentialIntegrator{MultiKetTrajectory},
     traj::NamedTrajectory,
 )
+    # Under a time warp the timestep rows are derived: re-derive them from the
+    # warp so Δtₖ = deltats(warp)[k] is what the defect consumes (no-op warp-free).
+    traj.warp !== nothing && sync_timesteps!(traj)
+
     # Extract globals once (constant across knot points)
     globals = extract_globals(ℰ, traj)
 
@@ -522,6 +530,14 @@ end
     # fall through to the retained sparse path (out of scope for the op, #205). The
     # default `matrix_free=false` keeps the assembled sparse Jacobian for the
     # Ipopt/MadNLP KKT-factorization path that shares this method.
+    # Derived-Δt dynamics (Piccolo.jl#321): with a warp the packed Jacobian
+    # drops the derived timestep column and gains the EXACT warp-parameter
+    # column (∂cₖ/∂θⱼ = wₖⱼ · ∂cₖ/∂Δtₖ). No warp → historical body, bit-unchanged.
+    # NOTE: the warp check precedes the matrix-free opt-in — the matrix-free op
+    # carries no warp column (out of scope here), so a warped trajectory always
+    # gets the assembled packed Jacobian.
+    traj.warp !== nothing && return _eval_jacobian_warped(ℰ, traj)
+
     if ℰ.matrix_free && !isnothing(ℰ.H_dirs)
         return matrix_free_jacobian_op(ℰ, traj)
     end
@@ -574,6 +590,11 @@ end
     traj::NamedTrajectory,
     μ::AbstractVector,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): with a warp the canonical Δt
+    # row/column maps onto the warp-parameter column through the exact chain
+    # rule. No warp → historical body, bit-unchanged.
+    traj.warp !== nothing && return _eval_hessian_of_lagrangian_warped(ℰ, traj, μ)
+
     N = traj.N
     x_dim = ℰ.x_dim
     u_dim = ℰ.u_dim
@@ -641,6 +662,10 @@ function get_hessian_of_lagrangian_structure(
     ℰ::HermitianExponentialIntegrator{MultiKetTrajectory},
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): packed coordinates + the warp
+    # column under a warp; historical structure otherwise.
+    traj.warp !== nothing && return _get_hessian_of_lagrangian_structure_warped(ℰ, traj)
+
     N = traj.N
     x_dim = ℰ.x_dim
     u_dim = ℰ.u_dim
@@ -1975,4 +2000,149 @@ end
     println("  [#203 AC4] avg fidelity: analytic=$fid_dk  ForwardDiff=$fid_fd")
     @test fid_dk > 0.99
     @test isapprox(fid_dk, fid_fd; atol = 1e-2)
+end
+
+# ============================================================================ #
+# Phase 1b (Piccolo.jl#321): the defect warp column under a time warp
+# (NamedTrajectories#161) — MultiKetTrajectory cell (shared propagator, one
+# derived Δt per knot feeding every ket's defect). Exact chain entries
+# ∂cₖ/∂θⱼ = (∂Δtₖ/∂θⱼ)·∂cₖ/∂Δtₖ with ∂cₖ/∂Δtₖ = −G(uₖ)·ψ̃ₖ₊₁ on the satisfied
+# defect, plus packed FD parity.
+# ============================================================================ #
+
+@testitem "HermitianExponentialIntegrator{MultiKet} defect warp column: exact entries + FD parity" begin
+    using Piccolo
+    using Piccolo.Control.QuantumIntegrators.ExponentialIntegrators:
+        _hermitian_exp_multiket, exp_eigen
+    using DirectTrajOpt
+    using NamedTrajectories
+    using TrajectoryIndexingUtils: slice
+    using Random
+    using LinearAlgebra
+    using SparseArrays
+    using Test
+
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X, PAULIS.Y], [1.0, 1.0])
+    N = 6
+    T0 = 1.7
+    Random.seed!(20260831)
+    ψ̃₁ = randn(4, N)
+    ψ̃₂ = randn(4, N)
+    u = 0.3 .* randn(2, N)
+
+    mk_traj(ψ̃₁, ψ̃₂) = NamedTrajectory(
+        (ψ̃₁ = ψ̃₁, ψ̃₂ = ψ̃₂, u = u, Δt = fill(T0 / (N - 1), 1, N));  # Δt derived
+        controls = (:u,),
+        timestep = :Δt,
+        warp = GlobalScale(T0),
+    )
+    traj = mk_traj(ψ̃₁, ψ̃₂)
+    ℰ = _hermitian_exp_multiket(sys, [:ψ̃₁, :ψ̃₂], :u, traj, Symbol[])
+
+    x_dim = ℰ.x_dim                      # 8 (two iso kets of 4)
+    wₖ = 1 / (N - 1)
+    T_col = (traj.dim - traj.dims[:Δt]) * traj.N + traj.global_dim + 1
+
+    # evaluate! reads the DERIVED rows (synced from the warp)
+    δ = zeros(x_dim * (N - 1))
+    evaluate!(δ, ℰ, traj)
+    @test !all(iszero, δ)
+    for k = 1:(N-1)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0))
+        @test δ[((k-1)*x_dim) .+ (1:4)] ≈ ψ̃₁[:, k+1] - Φₖ * ψ̃₁[:, k]
+        @test δ[((k-1)*x_dim) .+ (5:8)] ≈ ψ̃₂[:, k+1] - Φₖ * ψ̃₂[:, k]
+    end
+
+    # Jacobian: packed size + EXACT warp column (both kets share the chain)
+    ∂F = eval_jacobian(ℰ, traj)
+    @test size(∂F) == (x_dim * (N - 1), length(vec(traj)))
+    for k = 1:(N-1)
+        Gₖ = sys.G(u[:, k], 0.0)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0))
+        dcdΔt₁ = -Gₖ * Φₖ * ψ̃₁[:, k]
+        dcdΔt₂ = -Gₖ * Φₖ * ψ̃₂[:, k]
+        @test ∂F[((k-1)*x_dim) .+ (1:4), T_col] ≈ wₖ .* dcdΔt₁
+        @test ∂F[((k-1)*x_dim) .+ (5:8), T_col] ≈ wₖ .* dcdΔt₂
+    end
+
+    # satisfied defect: ∂cₖ/∂Δtₖ = −G(uₖ)·ψ̃ₖ₊₁ exactly (per ket)
+    ψ̃₁sat = copy(ψ̃₁)
+    ψ̃₂sat = copy(ψ̃₂)
+    for k = 1:(N-1)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0))
+        ψ̃₁sat[:, k+1] = Φₖ * ψ̃₁sat[:, k]
+        ψ̃₂sat[:, k+1] = Φₖ * ψ̃₂sat[:, k]
+    end
+    traj_sat = mk_traj(ψ̃₁sat, ψ̃₂sat)
+    ℰ_sat = _hermitian_exp_multiket(sys, [:ψ̃₁, :ψ̃₂], :u, traj_sat, Symbol[])
+    ∂F_sat = eval_jacobian(ℰ_sat, traj_sat)
+    for k = 1:(N-1)
+        @test ∂F_sat[((k-1)*x_dim) .+ (1:4), T_col] ≈
+              -wₖ .* (sys.G(u[:, k], 0.0) * ψ̃₁sat[:, k+1])
+        @test ∂F_sat[((k-1)*x_dim) .+ (5:8), T_col] ≈
+              -wₖ .* (sys.G(u[:, k], 0.0) * ψ̃₂sat[:, k+1])
+    end
+
+    # FD parity of the full Jacobian over the PACKED vector (perturbs T too)
+    function fd_jac(f, z0; h = 1e-6)
+        f0 = f(z0)
+        J = zeros(length(f0), length(z0))
+        for j in eachindex(z0)
+            e = zeros(length(z0))
+            e[j] = h
+            J[:, j] = (f(z0 .+ e) .- f(z0 .- e)) ./ (2h)
+        end
+        return J
+    end
+    f̂ = Z⃗ -> begin
+        unpack!(traj, Z⃗)
+        δ = zeros(x_dim * (N - 1))
+        evaluate!(δ, ℰ, traj)
+        return δ
+    end
+    z0 = collect(vec(traj))
+    ∂F_fd = fd_jac(f̂, z0)
+    @test all(isapprox.(∂F, ∂F_fd; atol = 1e-5, rtol = 1e-5))
+
+    # FD parity of the Hessian of the Lagrangian (exact mode)
+    μ = 0.3 .* collect(1.0:(x_dim*(N-1)))
+    H = eval_hessian_of_lagrangian(ℰ, traj, μ)
+    @test size(H) == (length(vec(traj)), length(vec(traj)))
+    function fd_hess(g, z0; h = 1e-4)
+        n = length(z0)
+        g0 = g(z0)
+        Hm = zeros(n, n)
+        for i = 1:n
+            ei = zeros(n)
+            ei[i] = h
+            Hm[i, i] = (g(z0 .+ ei) - 2g0 + g(z0 .- ei)) / h^2
+            for j = (i+1):n
+                ej = zeros(n)
+                ej[j] = h
+                Hm[i, j] =
+                    Hm[j, i] =
+                        (
+                            g(z0 .+ ei .+ ej) - g(z0 .+ ei .- ej) - g(z0 .- ei .+ ej) +
+                            g(z0 .- ei .- ej)
+                        ) / (4h^2)
+            end
+        end
+        return Hm
+    end
+    ĥ = Z⃗ -> begin
+        unpack!(traj, Z⃗)
+        δ = zeros(x_dim * (N - 1))
+        evaluate!(δ, ℰ, traj)
+        return μ'δ
+    end
+    H_fd = fd_hess(ĥ, z0)
+    @test all(isapprox.(H, triu(H_fd); atol = 2e-3, rtol = 2e-3))
+
+    # structures declare the warp column in packed coordinates
+    S = get_jacobian_structure(ℰ, traj)
+    @test size(S) == (x_dim * (N - 1), length(vec(traj)))
+    @test !iszero(S[slice(1, x_dim), T_col])
+    HS = get_hessian_of_lagrangian_structure(ℰ, traj)
+    @test size(HS) == (length(vec(traj)), length(vec(traj)))
+    @test any(!iszero, HS[T_col, :])
 end

--- a/src/control/integrators_exponential/hermitian_exponential_integrator_type.jl
+++ b/src/control/integrators_exponential/hermitian_exponential_integrator_type.jl
@@ -505,6 +505,13 @@ function get_hessian_of_lagrangian_structure(
     ℰ::AbstractExponentialIntegrator,
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): packed coordinates + the warp
+    # column under a warp; historical structure otherwise. (Hermitian cells
+    # only — the warp twin is Hermitian-specific.)
+    ℰ isa HermitianExponentialIntegrator &&
+        traj.warp !== nothing &&
+        return _get_hessian_of_lagrangian_structure_warped(ℰ, traj)
+
     N = traj.N
     global_dim = traj.global_dim
     z_dim = traj.dim

--- a/src/control/integrators_exponential/hermitian_exponential_integrator_unitary.jl
+++ b/src/control/integrators_exponential/hermitian_exponential_integrator_unitary.jl
@@ -670,6 +670,10 @@ function get_jacobian_structure(
     ℰ::HermitianExponentialIntegrator{UnitaryTrajectory},
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): packed two-knot windows + the warp
+    # column under a warp; historical structure otherwise.
+    traj.warp !== nothing && return _get_jacobian_structure_warped(ℰ, traj)
+
     N = traj.N
     x_dim = traj.dims[x_name(ℰ)]
     z_dim = traj.dim
@@ -709,6 +713,10 @@ end
     ℰ::HermitianExponentialIntegrator{UnitaryTrajectory},
     traj::NamedTrajectory,
 )
+    # Under a time warp the timestep rows are derived: re-derive them from the
+    # warp so Δtₖ = deltats(warp)[k] is what the defect consumes (no-op warp-free).
+    traj.warp !== nothing && sync_timesteps!(traj)
+
     # Extract globals once (constant across knot points)
     globals = extract_globals(ℰ, traj)
 
@@ -723,6 +731,11 @@ end
     ℰ::HermitianExponentialIntegrator{UnitaryTrajectory},
     traj::NamedTrajectory,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): with a warp the packed Jacobian
+    # drops the derived timestep column and gains the EXACT warp-parameter
+    # column (∂cₖ/∂θⱼ = wₖⱼ · ∂cₖ/∂Δtₖ). No warp → historical body, bit-unchanged.
+    traj.warp !== nothing && return _eval_jacobian_warped(ℰ, traj)
+
     N = traj.N
     x_dim = ℰ.x_dim
     z_dim = traj.dim
@@ -768,6 +781,11 @@ end
     traj::NamedTrajectory,
     μ::AbstractVector,
 )
+    # Derived-Δt dynamics (Piccolo.jl#321): with a warp the canonical Δt
+    # row/column maps onto the warp-parameter column through the exact chain
+    # rule. No warp → historical body, bit-unchanged.
+    traj.warp !== nothing && return _eval_hessian_of_lagrangian_warped(ℰ, traj, μ)
+
     N = traj.N
     x_dim = ℰ.x_dim
     u_dim = ℰ.u_dim
@@ -1535,4 +1553,140 @@ end
 
     traj2 = NamedTrajectory(qtraj, N)
     test_integrator(ℰ_on, traj2; atol = 1e-3, show_jacobian_diff = false)
+end
+
+# ============================================================================ #
+# Phase 1b (Piccolo.jl#321): the defect warp column under a time warp
+# (NamedTrajectories#161) — UnitaryTrajectory cell. Exact chain entries
+# ∂cₖ/∂θⱼ = (∂Δtₖ/∂θⱼ)·∂cₖ/∂Δtₖ with ∂cₖ/∂Δtₖ = −G(uₖ)·Ũₖ₊₁ on the satisfied
+# defect (vec over the stacked iso columns), plus packed FD parity.
+# ============================================================================ #
+
+@testitem "HermitianExponentialIntegrator{Unitary} defect warp column: exact entries + FD parity" begin
+    using Piccolo
+    using Piccolo.Control.QuantumIntegrators.ExponentialIntegrators:
+        _hermitian_exp_unitary, exp_eigen
+    using DirectTrajOpt
+    using NamedTrajectories
+    using TrajectoryIndexingUtils: slice
+    using Random
+    using LinearAlgebra
+    using SparseArrays
+    using Test
+
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X, PAULIS.Y], [1.0, 1.0])
+    N = 6
+    T0 = 1.7
+    Random.seed!(20260831)
+    Ũ⃗ = randn(8, N)   # stacked iso columns of a 2×2 "unitary" (values arbitrary for FD)
+    u = 0.3 .* randn(2, N)
+
+    mk_traj(Ũ⃗) = NamedTrajectory(
+        (Ũ⃗ = Ũ⃗, u = u, Δt = fill(T0 / (N - 1), 1, N));  # Δt ignored — derived
+        controls = (:u,),
+        timestep = :Δt,
+        warp = GlobalScale(T0),
+    )
+    traj = mk_traj(Ũ⃗)
+    ℰ = _hermitian_exp_unitary(sys, :Ũ⃗, :u, traj, Symbol[])
+
+    x_dim = ℰ.x_dim                      # 8 (2 iso columns of 4)
+    wₖ = 1 / (N - 1)
+    T_col = (traj.dim - traj.dims[:Δt]) * traj.N + traj.global_dim + 1
+
+    # evaluate! reads the DERIVED rows (synced from the warp)
+    δ = zeros(x_dim * (N - 1))
+    evaluate!(δ, ℰ, traj)
+    @test !all(iszero, δ)
+    for k = 1:(N-1)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0))
+        @test δ[((k-1)*x_dim) .+ (1:x_dim)] ≈ Ũ⃗[:, k+1] - vec(Φₖ * reshape(Ũ⃗[:, k], 4, 2))
+    end
+
+    # Jacobian: packed size + EXACT warp column
+    ∂F = eval_jacobian(ℰ, traj)
+    @test size(∂F) == (x_dim * (N - 1), length(vec(traj)))
+    for k = 1:(N-1)
+        Gₖ = sys.G(u[:, k], 0.0)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0))
+        dcdΔt = -vec(Gₖ * Φₖ * reshape(Ũ⃗[:, k], 4, 2))   # ∂cₖ/∂Δtₖ
+        @test ∂F[((k-1)*x_dim) .+ (1:x_dim), T_col] ≈ wₖ .* dcdΔt
+    end
+
+    # satisfied defect: ∂cₖ/∂Δtₖ = −G(uₖ)·Ũₖ₊₁ exactly
+    Ũ⃗sat = copy(Ũ⃗)
+    for k = 1:(N-1)
+        Φₖ = exp_eigen((T0 / (N - 1)) .* sys.H(u[:, k], 0.0))
+        Ũ⃗sat[:, k+1] = vec(Φₖ * reshape(Ũ⃗sat[:, k], 4, 2))
+    end
+    traj_sat = mk_traj(Ũ⃗sat)
+    ℰ_sat = _hermitian_exp_unitary(sys, :Ũ⃗, :u, traj_sat, Symbol[])
+    ∂F_sat = eval_jacobian(ℰ_sat, traj_sat)
+    for k = 1:(N-1)
+        @test ∂F_sat[((k-1)*x_dim) .+ (1:x_dim), T_col] ≈
+              -wₖ .* vec(sys.G(u[:, k], 0.0) * reshape(Ũ⃗sat[:, k+1], 4, 2))
+    end
+
+    # FD parity of the full Jacobian over the PACKED vector (perturbs T too)
+    function fd_jac(f, z0; h = 1e-6)
+        f0 = f(z0)
+        J = zeros(length(f0), length(z0))
+        for j in eachindex(z0)
+            e = zeros(length(z0))
+            e[j] = h
+            J[:, j] = (f(z0 .+ e) .- f(z0 .- e)) ./ (2h)
+        end
+        return J
+    end
+    f̂ = Z⃗ -> begin
+        unpack!(traj, Z⃗)
+        δ = zeros(x_dim * (N - 1))
+        evaluate!(δ, ℰ, traj)
+        return δ
+    end
+    z0 = collect(vec(traj))
+    ∂F_fd = fd_jac(f̂, z0)
+    @test all(isapprox.(∂F, ∂F_fd; atol = 1e-5, rtol = 1e-5))
+
+    # FD parity of the Hessian of the Lagrangian (exact mode)
+    μ = 0.3 .* collect(1.0:(x_dim*(N-1)))
+    H = eval_hessian_of_lagrangian(ℰ, traj, μ)
+    @test size(H) == (length(vec(traj)), length(vec(traj)))
+    function fd_hess(g, z0; h = 1e-4)
+        n = length(z0)
+        g0 = g(z0)
+        Hm = zeros(n, n)
+        for i = 1:n
+            ei = zeros(n)
+            ei[i] = h
+            Hm[i, i] = (g(z0 .+ ei) - 2g0 + g(z0 .- ei)) / h^2
+            for j = (i+1):n
+                ej = zeros(n)
+                ej[j] = h
+                Hm[i, j] =
+                    Hm[j, i] =
+                        (
+                            g(z0 .+ ei .+ ej) - g(z0 .+ ei .- ej) - g(z0 .- ei .+ ej) +
+                            g(z0 .- ei .- ej)
+                        ) / (4h^2)
+            end
+        end
+        return Hm
+    end
+    ĥ = Z⃗ -> begin
+        unpack!(traj, Z⃗)
+        δ = zeros(x_dim * (N - 1))
+        evaluate!(δ, ℰ, traj)
+        return μ'δ
+    end
+    H_fd = fd_hess(ĥ, z0)
+    @test all(isapprox.(H, triu(H_fd); atol = 2e-3, rtol = 2e-3))
+
+    # structures declare the warp column in packed coordinates
+    S = get_jacobian_structure(ℰ, traj)
+    @test size(S) == (x_dim * (N - 1), length(vec(traj)))
+    @test !iszero(S[slice(1, x_dim), T_col])
+    HS = get_hessian_of_lagrangian_structure(ℰ, traj)
+    @test size(HS) == (length(vec(traj)), length(vec(traj)))
+    @test any(!iszero, HS[T_col, :])
 end

--- a/src/control/integrators_exponential/warp_plumbing.jl
+++ b/src/control/integrators_exponential/warp_plumbing.jl
@@ -1,0 +1,342 @@
+# ============================================================================ #
+# Warp plumbing — derived-Δt support for the Hermitian exponential family
+# (NamedTrajectories#161 time warp; Piccolo.jl#321, Phase 1b of the TR
+# integration, mirroring DirectTrajOpt#150's WarpPlumbing shape).
+#
+# Under a time warp the trajectory's timestep rows are DERIVED: present as
+# components (so `traj[k].timestep` keeps reading) but excluded from the packed
+# decision vector. The packed layout of `vec(traj)` is
+#
+#     [ non-derived rows of knot 1 … knot N ] ++ [ global data ] ++ [ warp params ]
+#
+# with `n_params(warp)` trailing entries — for `GlobalScale`, the scalar
+# duration `T`. Every integrator surface that addresses the packed vector
+# (`eval_jacobian`, `eval_hessian_of_lagrangian`, the structure functions) must
+# use these packed positions and expose the warp-parameter column with the
+# EXACT chain entries `∂Δtₖ/∂θⱼ` (`ddeltats_dparams`, the NT#161 API — exact
+# rational lattice weights for `GlobalScale`, generic ForwardDiff through
+# `with_params` otherwise). Without a warp every helper below is unused: the
+# warp-free code paths are bit-unchanged.
+#
+# NOTE: these are defined HERE, not imported from `DirectTrajOpt.WarpPlumbing`,
+# because the pinned DTO 0.10.1 predates the warp release — the DTO-side
+# Evaluator plumbing (post-#150) is only exercised by the cross-repo
+# end-to-end smoke (two-repo dev env, see the #321 receipt).
+# ============================================================================ #
+
+"""
+    _packed_knot_dim(traj)::Int
+
+Per-knot width of the packed vector: all component rows except the derived
+timestep. Without a warp this equals `traj.dim` (the helper is then unused).
+"""
+_packed_knot_dim(traj::NamedTrajectory) =
+    traj.warp === nothing ? traj.dim : traj.dim - traj.dims[traj.timestep]
+
+"""
+    _packed_length(traj)::Int
+
+Total length of the packed decision vector: `== length(vec(traj))`. Without a
+warp this is the historical `traj.dim * traj.N + traj.global_dim`.
+"""
+_packed_length(traj::NamedTrajectory) = length(traj)
+
+"""
+    _packed_row_index(traj, k, r)::Int
+
+Packed position of knot `k`'s datavec row `r` (1-based within the knot). The
+derived timestep row has NO packed position — it is never decision data — and
+asking for it errors. Without a warp this is the historical
+`index(k, r, traj.dim)`.
+"""
+function _packed_row_index(traj::NamedTrajectory, k::Int, r::Int)
+    if traj.warp === nothing
+        return TrajectoryIndexingUtils.index(k, r, traj.dim)
+    end
+    zdim = _packed_knot_dim(traj)
+    dt_first = first(traj.components[traj.timestep])
+    dt_dim = traj.dims[traj.timestep]
+    dt_first ≤ r < dt_first + dt_dim && error(
+        "the derived timestep row has no packed index — it is never decision data " *
+        "under a time warp (NamedTrajectories#161)",
+    )
+    return (k - 1) * zdim + (r ≤ dt_first ? r : r - dt_dim)
+end
+
+"""
+    _packed_slice(traj, k, comps)::Vector{Int}
+
+Packed positions of knot `k`'s component rows `comps` (datavec rows, 1-based
+within a knot, none derived). Without a warp this is the historical
+`slice(k, comps, traj.dim)` — bit-identical.
+"""
+_packed_slice(traj::NamedTrajectory, k::Int, comps) =
+    [_packed_row_index(traj, k, r) for r in comps]
+
+"""
+    _warp_param_indices(traj)::Vector{Int}
+
+Packed positions of the warp parameters (empty without a warp) — the trailing
+block of `vec(traj)`. For `GlobalScale` this is the single duration variable
+`T`.
+"""
+function _warp_param_indices(traj::NamedTrajectory)
+    warp = traj.warp
+    warp === nothing && return Int[]
+    base = _packed_knot_dim(traj) * traj.N + traj.global_dim
+    return [base + j for j = 1:n_params(warp)]
+end
+
+"""
+    _warp_chain(traj)
+
+Exact chain rule `∂Δtₖ/∂θⱼ` for the trajectory's warp as an `(N-1) × n_params`
+matrix — [`NamedTrajectories.ddeltats_dparams`](@ref), the NT#161 API: the
+EXACT rational lattice weights `1/(N-1)` for `GlobalScale` (its override — no
+floating subtraction), the generic ForwardDiff pass through `with_params`
+(the Dual rebuild AD seam) for any other warp.
+"""
+_warp_chain(traj::NamedTrajectory) = ddeltats_dparams(traj.warp, traj.N)
+
+# ---------------------------------------------------------------------------- #
+# Shared warp-path assembly for the Hermitian exponential family. All three
+# cells (Unitary/Ket/MultiKet) share the same canonical per-knot derivative
+# layout `[xₖ, uₖ, Δtₖ, xₖ₊₁]` (+ globals), so the packed re-assembly — with
+# the Δt column/row mapped onto the warp-parameter column through the exact
+# chain rule — is written once here and dispatched to from each cell's
+# `eval_jacobian` / `eval_hessian_of_lagrangian` / structure functions.
+#
+# Routing stays ENUMERATED: each cell's public API function guards
+# `traj.warp !== nothing` and routes to its warp twin; no warp → the
+# historical body, bit-unchanged.
+# ---------------------------------------------------------------------------- #
+
+"""
+    _hermitian_warp_comps(ℰ, traj) -> (x_cols, u_cols, Δt_col, x1_cols, g_cols_full)
+
+Per-knot matrix column indices for the state, control, derived-timestep,
+next-state, and global blocks — CONSTRUCTION-time components (`ℰ.var_comps`,
+`ℰ.z_dim`): the preallocated per-knot `∂ℰs` were laid out by
+`jacobian_structure` on the integrator's construction trajectory, and the
+eval-time trajectory may carry extra components (e.g. du/ddu added by the
+smooth-pulse template) that shift the eval-time component rows.
+"""
+function _hermitian_warp_comps(ℰ::HermitianExponentialIntegrator, traj::NamedTrajectory)
+    x_cols = collect(ℰ.var_comps[1:ℰ.x_dim])
+    u_cols = collect(ℰ.var_comps[(ℰ.x_dim+1):(ℰ.x_dim+ℰ.u_dim)])
+    Δt_col = ℰ.var_comps[end]
+    x1_cols = ℰ.z_dim .+ x_cols
+    g_cols_full = ℰ.global_dim > 0 ? _global_full_cols(ℰ, traj) : Int[]
+    return x_cols, u_cols, Δt_col, x1_cols, g_cols_full
+end
+
+"""
+    _hermitian_eval_comps(ℰ, traj) -> (x_cols, u_cols)
+
+Eval-time trajectory component rows of the state and control blocks — the
+TARGET side of the packed re-assembly (the packed positions of the eval-time
+trajectory's own data).
+"""
+function _hermitian_eval_comps(ℰ::HermitianExponentialIntegrator, traj::NamedTrajectory)
+    x_cols = vcat([collect(traj.components[name]) for name in ℰ.x_names]...)
+    u_cols = collect(traj.components[ℰ.u_name])
+    return x_cols, u_cols
+end
+
+"""
+    _eval_jacobian_warped(ℰ, traj)
+
+Warp-path Jacobian of the defects. Per knot the preallocated `∂ℰs[k]` is filled
+by the cell's own `jacobian!` (unchanged — the derived Δtₖ is read from the
+trajectory rows, which [`sync_timesteps!`](@ref) re-derives from the warp), and
+the per-knot block is scattered into PACKED coordinates with the derived-Δt
+column replaced by the EXACT warp column:
+
+    ∂cₖ/∂θⱼ = (∂Δtₖ/∂θⱼ) · ∂cₖ/∂Δtₖ ,   ∂Δtₖ/∂θⱼ = ddeltats_dparams(warp, N)[k, j]
+
+i.e. `wₙ · ∂cₙ/∂Δtₙ` per warp parameter — for `GlobalScale`, `∂cₖ/∂T =
+∂cₖ/∂Δtₖ / (N-1)`. On the satisfied defect `∂cₙ/∂Δtₙ = −G(uₙ)·xₙ₊₁` exactly.
+"""
+function _eval_jacobian_warped(ℰ::HermitianExponentialIntegrator, traj::NamedTrajectory)
+    sync_timesteps!(traj)
+    N = traj.N
+    x_dim = ℰ.x_dim
+    F_dim = x_dim * (N - 1)
+    Z_dim = _packed_length(traj)
+    warp_cols = _warp_param_indices(traj)
+    chain = _warp_chain(traj)   # (N-1) × n_params
+
+    globals = extract_globals(ℰ, traj)
+    Threads.@threads for k = 1:(N-1)
+        jacobian!(ℰ.∂ℰs[k], ℰ, traj[k], traj[k+1], k, globals)
+    end
+
+    x_cols, u_cols, Δt_col, x1_cols, g_cols_full = _hermitian_warp_comps(ℰ, traj)
+    x_cols_e, u_cols_e = _hermitian_eval_comps(ℰ, traj)
+
+    ∂F = spzeros(F_dim, Z_dim)
+    @inbounds for k = 1:(N-1)
+        Mₖ = ℰ.∂ℰs[k]
+        ∂F[slice(k, x_dim), _packed_slice(traj, k, x_cols_e)] = Mₖ[:, x_cols]
+        ∂F[slice(k, x_dim), _packed_slice(traj, k, u_cols_e)] = Mₖ[:, u_cols]
+        ∂F[slice(k, x_dim), _packed_slice(traj, k+1, x_cols_e)] = Mₖ[:, x1_cols]
+        # the warp column: chain-rule products of the per-knot ∂cₖ/∂Δtₖ entries
+        ∂F[slice(k, x_dim), warp_cols] = Mₖ[:, Δt_col] * transpose(chain[k, :])
+    end
+    if ℰ.global_dim > 0
+        g_cols_local = (2*ℰ.z_dim+1):(2*ℰ.z_dim+ℰ.global_dim)
+        @inbounds for k = 1:(N-1)
+            ∂F[slice(k, x_dim), g_cols_full] = ℰ.∂ℰs[k][:, g_cols_local]
+        end
+    end
+    return ∂F
+end
+
+"""
+    _eval_hessian_of_lagrangian_warped(ℰ, traj, μ)
+
+Warp-path Hessian of the Lagrangian. Per knot the canonical `μ∂²ℰs[k]` (layout
+`[xₖ, uₖ, Δtₖ, xₖ₊₁]` + globals) is filled by the cell's own
+`hessian_of_lagrangian!` (unchanged), then re-assembled in PACKED coordinates
+with the canonical Δt row/column mapped onto the warp-parameter column through
+the exact chain rule:
+
+    ∂²(μ'cₖ)/∂v∂θⱼ = (∂Δtₖ/∂θⱼ) · ∂²(μ'cₖ)/∂v∂Δtₖ ,
+    ∂²(μ'cₖ)/∂θⱼ∂θⱼ' = (∂Δtₖ/∂θⱼ)(∂Δtₖ/∂θⱼ') · ∂²(μ'cₖ)/∂Δtₖ² .
+
+Covers the x-Δt / u-Δt / Δt-g cross-terms and the Δt-Δt term exactly as the
+canonical structure declares them (u-Δt / Δt-g / Δt-Δt dropped in
+Gauss–Newton mode, mirroring the warp-free path).
+"""
+function _eval_hessian_of_lagrangian_warped(
+    ℰ::HermitianExponentialIntegrator,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    sync_timesteps!(traj)
+    N = traj.N
+    x_dim, u_dim = ℰ.x_dim, ℰ.u_dim
+    knot_dim = x_dim + u_dim + 1
+    Z_dim = _packed_length(traj)
+    warp_cols = _warp_param_indices(traj)
+    nθ = length(warp_cols)
+    chain = _warp_chain(traj)
+    Δt_can = knot_dim
+
+    globals = extract_globals(ℰ, traj)
+    Threads.@threads for k = 1:(N-1)
+        μₖ = μ[slice(k, x_dim)]
+        hessian_of_lagrangian!(ℰ.μ∂²ℰs[k], ℰ, μₖ, traj[k], traj[k+1], k, globals)
+    end
+
+    x_cols, u_cols, _, _, g_cols_full = _hermitian_warp_comps(ℰ, traj)
+    x_cols_e, u_cols_e = _hermitian_eval_comps(ℰ, traj)
+
+    # canonical rows/cols of the per-knot Hessian EXCLUDING Δt, in [x, u, x₊₁, g] order
+    C_plain = [collect(1:(x_dim+u_dim)); collect((knot_dim+1):(knot_dim+x_dim))]
+    C =
+        ℰ.global_dim > 0 ? [C_plain; collect((2*knot_dim+1):(2*knot_dim+ℰ.global_dim))] :
+        C_plain
+
+    μ∂²F = spzeros(Z_dim, Z_dim)
+    @inbounds for k = 1:(N-1)
+        Mₖ = ℰ.μ∂²ℰs[k]
+        Z = [
+            _packed_slice(traj, k, x_cols_e);
+            _packed_slice(traj, k, u_cols_e);
+            _packed_slice(traj, k+1, x_cols_e);
+            g_cols_full;
+        ]
+        μ∂²F[Z, Z] .+= Mₖ[C, C]
+        for j = 1:nθ
+            w = chain[k, j]
+            iszero(w) && continue
+            μ∂²F[Z, warp_cols[j]] .+= w .* Mₖ[C, Δt_can]
+            μ∂²F[warp_cols[j], Z] .+= w .* Mₖ[Δt_can, C]
+        end
+        μ∂²F[warp_cols, warp_cols] .+=
+            Mₖ[Δt_can, Δt_can] .* (chain[k, :] * transpose(chain[k, :]))
+    end
+    return triu(μ∂²F)
+end
+
+"""
+    _get_jacobian_structure_warped(ℰ, traj)
+
+Warp-path Jacobian STRUCTURE: packed two-knot windows (x, u; x₊₁) plus the
+warp-parameter column (declared with ones — a conservative superset of the
+exact `chain[k, j] · ∂cₖ/∂Δtₖ` nonzeros, safe for the solver's preallocation),
+in the same coordinates the DTO Evaluator's packed path consumes.
+"""
+function _get_jacobian_structure_warped(
+    ℰ::HermitianExponentialIntegrator,
+    traj::NamedTrajectory,
+)
+    N = traj.N
+    x_dim = ℰ.x_dim
+    ∂F = spzeros(x_dim * (N - 1), _packed_length(traj))
+    warp_cols = _warp_param_indices(traj)
+    _, _, _, _, g_cols_full = _hermitian_warp_comps(ℰ, traj)
+    x_cols_e, u_cols_e = _hermitian_eval_comps(ℰ, traj)
+
+    for k = 1:(N-1)
+        cols = [
+            _packed_slice(traj, k, x_cols_e);
+            _packed_slice(traj, k, u_cols_e);
+            warp_cols;
+            _packed_slice(traj, k+1, x_cols_e);
+        ]
+        ∂F[slice(k, x_dim), cols] .= 1.0
+    end
+    if ℰ.global_dim > 0
+        for k = 1:(N-1)
+            ∂F[slice(k, x_dim), g_cols_full] .= 1.0
+        end
+    end
+    return ∂F
+end
+
+"""
+    _get_hessian_of_lagrangian_structure_warped(ℰ, traj)
+
+Warp-path Hessian-of-the-Lagrangian STRUCTURE: the canonical structure
+(`hessian_structure` in `[xₖ, uₖ, Δtₖ, xₖ₊₁]` + globals ordering, Gauss–Newton
+mode respected) re-assembled in packed coordinates with the canonical Δt
+row/column mapped onto the warp-parameter column (conservative ones).
+"""
+function _get_hessian_of_lagrangian_structure_warped(
+    ℰ::HermitianExponentialIntegrator,
+    traj::NamedTrajectory,
+)
+    N = traj.N
+    x_dim, u_dim, global_dim = ℰ.x_dim, ℰ.u_dim, ℰ.global_dim
+    knot_dim = x_dim + u_dim + 1
+    M_can = hessian_structure(x_dim, u_dim, global_dim; gauss_newton = ℰ.gauss_newton)
+    warp_cols = _warp_param_indices(traj)
+    nθ = length(warp_cols)
+    Δt_can = knot_dim
+
+    _, _, _, _, g_cols_full = _hermitian_warp_comps(ℰ, traj)
+    x_cols_e, u_cols_e = _hermitian_eval_comps(ℰ, traj)
+    C_plain = [collect(1:(x_dim+u_dim)); collect((knot_dim+1):(knot_dim+x_dim))]
+    C =
+        global_dim > 0 ? [C_plain; collect((2*knot_dim+1):(2*knot_dim+global_dim))] :
+        C_plain
+
+    μ∂²F = spzeros(_packed_length(traj), _packed_length(traj))
+    for k = 1:(N-1)
+        Z = [
+            _packed_slice(traj, k, x_cols_e);
+            _packed_slice(traj, k, u_cols_e);
+            _packed_slice(traj, k+1, x_cols_e);
+            g_cols_full;
+        ]
+        μ∂²F[Z, Z] .+= M_can[C, C]
+        for j = 1:nθ
+            μ∂²F[Z, warp_cols[j]] .+= 1.0
+            μ∂²F[warp_cols[j], Z] .+= 1.0
+        end
+        μ∂²F[warp_cols, warp_cols] .+= 1.0
+    end
+    return μ∂²F
+end


### PR DESCRIPTION
TR Phase 1b Piccolo side (issue #321; DTO side = #150, merged; NT warp layer = v0.9.4, registered).

`HermitianExponentialIntegrator` (Unitary/Ket/MultiKet cells) gains the warp column:
- Derived-Δt reads from the trajectory's warp (`deltats(warp)`) instead of the raw row when present; `evaluate!` syncs via `sync_timesteps!` (no-op warp-free).
- Defect Jacobian/Hessian structures declare the warp slot with EXACT entries (wₙ·∂cₙ/∂Δtₙ = wₙ·(−G(uₙ)xₙ₊₁) on the satisfied defect); per-knot canonical blocks filled by the UNCHANGED cell jacobian!/hessian! and re-assembled in packed coordinates through the exact `ddeltats_dparams` chain (rational weights for GlobalScale, `with_params` Dual rebuild otherwise). Gauss-Newton exact-HVP widening covered by the shared mapping.
- Routing stays ENUMERATED; warp check precedes the multiket matrix_free opt-in; NonHermitian density + Magnus/spline cells out of scope per Key Decisions.
- **No warp: bit-unchanged** — guarded returns, zero existing-test modifications.

**End-to-end (two-repo smoke, DTO@main evaluator):** 1q unitary X gate, warp as the ONLY free time quantity: T solved 20 → 17.94 ns, F_solve = 0.99999999996, F_roll parity 3e-16 through the derived Δtₖ(T) rollout. The warp-free arm: F = 0.99999982.

TDD: 88/88 FD-parity testitems (25 Ket / 24 Unitary / 39 MultiKet), RED verified (56F+8E pre-fix — the RED phase caught a construction-vs-packed coordinate split that took the smoke from F=0.07 to F≈1). Full suite at pushed head 507362a3: **5805 pass / 0 fail / 7 pre-existing broken**.

Also surfaced (DTO-side, being filed separately): bare `DirectTrajOptProblem` + TerminalObjective stalls Ipopt into restoration warp-free on pinned DTO 0.10.1 — evaluator verified correct; probe evidence in the audit trail.