### PR TITLE
feat(3c): spline-shape constraint family + Hermite primitives + bending regularizer to Piccolo (open-core slice 3c)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,7 @@ DirectTrajOpt = "0.9.5, 0.10"
 Distributions = "0.25"
 ExponentialAction = "0.2"
 ExponentialUtilities = "1"
+FiniteDiff = "2.29"
 ForwardDiff = "1.3"
 JET = "0.9, 0.10, 0.11"
 JLD2 = "0.6"
@@ -91,6 +92,7 @@ julia = "1.12"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"
@@ -98,4 +100,4 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "CairoMakie", "JET", "Logging", "QuantumToolbox", "Serialization", "Test"]
+test = ["Aqua", "BenchmarkTools", "CairoMakie", "FiniteDiff", "JET", "Logging", "QuantumToolbox", "Serialization", "Test"]

--- a/src/control/constraints.jl
+++ b/src/control/constraints.jl
@@ -784,4 +784,63 @@ end
     @test all(g .≈ -1/9)
 end
 
+# ─────────────────────────────────────────────────────────────────────────── #
+# Spline-shape constraint family (open-core slice 3c, #431).                  #
+#                                                                             #
+# Moved from Piccolissimo (moved-file manifest rows 20–25, plus the shared     #
+# Hermite primitives and the ADR-0010 stencil table/kernels the family owns). #
+# The submodule carries its own export surface; the re-export block appended   #
+# at the GREEN step is the top-level seam, kept complete by the drift guard    #
+# in test/test_spline_reexport_seam.jl.                                        #
+# ─────────────────────────────────────────────────────────────────────────── #
+
+include("constraints_spline/_spline_constraints.jl")
+using .SplineConstraints
+
+# The submodule name itself rides the seam (the SplineIntegrators convention):
+# Piccolissimo's seam and the drift guard reach the module through this export.
+export SplineConstraints
+
+# ── Top-level re-export seam (slice 3c, #431) ────────────────────────────── #
+# EVERY family-owned name the submodule exports resolves at Piccolo top level;
+# the drift guard in test/test_spline_reexport_seam.jl fails if this block and
+# the submodule's export surface drift apart (#326's lesson, applied upfront).
+# CommonInterface-owned functions (evaluate!, jacobian!, ...) are deliberately
+# NOT re-exported here: interface functions come from CommonInterface, which
+# `using Piccolo` already reaches through the DirectTrajOpt re-export.
+export OptimizedNonlinearKnotPointConstraint, NonlinearSegmentConstraint
+export CubicSplineExtremaConstraint,
+    CubicSplineSufficientBoundConstraint, CubicSplineSlopeConstraint
+export CubicSplineBoundConstraint, HermiteSmoothAccelerationConstraint
+export ConstraintStencilTable
+export stencil_structure,
+    stencil_fill_values!,
+    stencil_assemble!,
+    stencil_scatter_functional!,
+    stencil_expand_rows!,
+    stencil_coeff_range,
+    stencil_functional_rows,
+    stencil_n_entries,
+    stencil_width
+export stencil_refresh_token,
+    stencil_touch!,
+    stencil_jvp!,
+    stencil_vjp!,
+    constraint_stencil_table,
+    refresh_constraint_coefficients!,
+    supports_matrix_free_constraint_gradient,
+    UNBOUNDED_STENCIL_WIDTH
+export supports_matrix_free_constraint_hvp,
+    constraint_stencil_hvp!, stencil_functional_weight
+export hermite_basis_functions,
+    hermite_derivative_basis,
+    evaluate_hermite_spline,
+    evaluate_hermite_derivative,
+    hermite_value_gradient,
+    hermite_accel_start,
+    hermite_accel_end,
+    hermite_accel_start_gradient,
+    hermite_accel_end_gradient,
+    hermite_accel_jump_gradient
+
 end

--- a/src/control/constraints_spline/_spline_constraints.jl
+++ b/src/control/constraints_spline/_spline_constraints.jl
@@ -1,0 +1,126 @@
+# ============================================================================ #
+# SplineConstraints — spline-shape constraint family (Piccolo home).
+#
+# Open-core slice 3c (harmoniqs/Piccolissimo.jl#431). This module owns the
+# nonlinear knot/segment constraint types, the spline bound/extrema/slope
+# family, the two stencil-table constraints (`CubicSplineBoundConstraint`,
+# `HermiteSmoothAccelerationConstraint`), the functional-indexed
+# `ConstraintStencilTable` with its host application kernels (ADR-0010), and
+# the one-definition Hermite primitives — moved from Piccolissimo per
+# docs/moved-file-review.md rows 20–25 of the open-core split's manifest.
+#
+# What STAYED in Piccolissimo (proprietary): the device stencil table (#333),
+# knot-axis sharding (#334), the Altissimo backends that consume this surface,
+# and `HermiteC2Regularizer` (row 26 struck by amendment 9 — deprecated there,
+# removed on the later C2 arc; see that repo's
+# `objectives/hermite_c2_regularizer.jl`). `HermiteBendingEnergyRegularizer`
+# moved in slice 3a (#309) and lives in QuantumObjectives.
+#
+# No extension seams are needed this slice: the moved family is
+# self-contained, and the dependency arrow runs Piccolissimo → Piccolo (the
+# stays import this surface back — the 3a/3b convention).
+# ============================================================================ #
+
+module SplineConstraints
+
+using SparseArrays
+using ForwardDiff
+using LinearAlgebra
+using NamedTrajectories
+using TrajectoryIndexingUtils
+using TestItemRunner
+
+using DirectTrajOpt
+using DirectTrajOpt: AbstractNonlinearConstraint
+
+# Import the common interface functions (defined in CommonInterface).
+# These are the generic functions we extend with our concrete implementations.
+# Imported WITHOUT export: interface functions come from CommonInterface (the
+# drift-guard seam convention, see test/test_spline_reexport_seam.jl).
+using DirectTrajOpt.CommonInterface
+import DirectTrajOpt.CommonInterface:
+    evaluate!, jacobian_structure, jacobian!, hessian_structure, hessian_of_lagrangian
+import DirectTrajOpt.CommonInterface: eval_jacobian, eval_hessian_of_lagrangian
+
+# Import constraint-specific functions (defined in DirectTrajOpt.Constraints).
+# Note: These are constraint-specific, not part of CommonInterface.
+import DirectTrajOpt.Constraints: get_full_jacobian, get_full_hessian
+import DirectTrajOpt.Constraints: jacobian!, hessian_of_lagrangian!
+
+# ── Family surface ───────────────────────────────────────────────────────── #
+export OptimizedNonlinearKnotPointConstraint
+export NonlinearSegmentConstraint
+export CubicSplineExtremaConstraint,
+    CubicSplineSufficientBoundConstraint, CubicSplineSlopeConstraint
+export CubicSplineBoundConstraint
+export HermiteSmoothAccelerationConstraint
+
+# The functional-indexed stencil table (ADR-0010) and its generic application
+# kernels. Consumers: `HermiteSmoothAccelerationConstraint` (#330, two-interval
+# continuity rows) and `CubicSplineBoundConstraint` (#331, single-interval
+# sample rows). The kernels were reused UNCHANGED by the second port — the
+# table needed no widening.
+export ConstraintStencilTable
+export stencil_structure,
+    stencil_fill_values!,
+    stencil_assemble!,
+    stencil_scatter_functional!,
+    stencil_expand_rows!,
+    stencil_coeff_range,
+    stencil_functional_rows,
+    stencil_n_entries,
+    stencil_width
+
+# Coefficient-refresh bookkeeping and the constraint-type gradient trait (#332).
+# `supports_matrix_free_constraint_gradient` is the inequality-path sibling of
+# the backend's `_supports_matrix_free_eq_gradient`; a constraint opts in by
+# defining `constraint_stencil_table` + `refresh_constraint_coefficients!` and
+# routability is then DERIVED from the declared stencil width. The application
+# kernels' DEVICE half (#333) and the sharded path (#334) stayed in
+# Piccolissimo and extend this surface from there.
+export stencil_refresh_token,
+    stencil_touch!,
+    stencil_jvp!,
+    stencil_vjp!,
+    constraint_stencil_table,
+    refresh_constraint_coefficients!,
+    supports_matrix_free_constraint_gradient,
+    UNBOUNDED_STENCIL_WIDTH
+
+# The exact inequality HVP trait (#458): DECLARED per family (unlike the
+# DERIVED gradient trait — no structural property of a table implies a
+# second-order action), with the per-functional weight contraction shared by
+# every opting-in family.
+export supports_matrix_free_constraint_hvp,
+    constraint_stencil_hvp!, stencil_functional_weight
+
+# Cubic Hermite spline primitives — one definition, shared by every spline constraint.
+export hermite_basis_functions,
+    hermite_derivative_basis,
+    evaluate_hermite_spline,
+    evaluate_hermite_derivative,
+    hermite_value_gradient,
+    hermite_accel_start,
+    hermite_accel_end,
+    hermite_accel_start_gradient,
+    hermite_accel_end_gradient,
+    hermite_accel_jump_gradient
+
+# ── Includes (definition order matters) ──────────────────────────────────── #
+include("hermite_primitives.jl")
+include("stencil_table.jl")
+include("nonlinear_knot_point_constraint.jl")
+include("nonlinear_segment_constraint.jl")
+include("spline_bound_constraints.jl")
+include("cubic_spline_bound_constraint.jl")
+include("hermite_smooth_acceleration_constraint.jl")
+# `cubic_spline_bound_constraint.jl` and `hermite_smooth_acceleration_constraint.jl`
+# come after the primitives + table they build on; they are mutually independent
+# (neither references the other's symbols), so their relative order is free.
+
+# Create alias for the optimized version (exported; the bare struct name stays
+# internal so `using Piccolo` keeps resolving DirectTrajOpt's
+# `NonlinearKnotPointConstraint` without ambiguity).
+const OptimizedNonlinearKnotPointConstraint = NonlinearKnotPointConstraint
+
+end

--- a/src/control/constraints_spline/cubic_spline_bound_constraint.jl
+++ b/src/control/constraints_spline/cubic_spline_bound_constraint.jl
@@ -824,14 +824,11 @@ end
 @testitem "#331 AC1/AC2/AC5: ported residual matches the reference; Jacobian matches forward-mode AD" begin
     using NamedTrajectories
 
-    CubicSplineBoundConstraint,
-    evaluate!,
-    jacobian!,
-    jacobian_structure,
-    eval_jacobian,
-    get_full_jacobian,
-    _csb_reference_evaluate!,
-    _csb_reference_jacobian
+    using Piccolo: CubicSplineBoundConstraint, eval_jacobian
+    using DirectTrajOpt.CommonInterface: evaluate!, jacobian_structure
+    using DirectTrajOpt.Constraints: get_full_jacobian, jacobian!
+    using Piccolo.Control.QuantumConstraints.SplineConstraints:
+        _csb_reference_evaluate!, _csb_reference_jacobian
     using ForwardDiff
     using SparseArrays
     using LinearAlgebra
@@ -966,7 +963,9 @@ end
 @testitem "#331 AC3: residual and Jacobian allocation are invariant to knot count" begin
     using NamedTrajectories
 
-    CubicSplineBoundConstraint, evaluate!, jacobian!, eval_jacobian
+    using Piccolo: CubicSplineBoundConstraint, eval_jacobian
+    using DirectTrajOpt.CommonInterface: evaluate!
+    using DirectTrajOpt.Constraints: jacobian!
     using Random
 
     # KNOT-FLATNESS, not zero allocation. The interface hands the constraint a trajectory
@@ -1025,12 +1024,13 @@ end
 @testitem "#331 AC6: declared stencil width of one, and the declared structure it implies" begin
     using NamedTrajectories
 
-    CubicSplineBoundConstraint,
-    eval_jacobian,
-    stencil_width,
-    stencil_coeff_range,
-    stencil_functional_rows,
-    hermite_value_gradient
+    using Piccolo:
+        CubicSplineBoundConstraint,
+        eval_jacobian,
+        hermite_value_gradient,
+        stencil_coeff_range,
+        stencil_functional_rows,
+        stencil_width
     using Random
 
     Random.seed!(0x331AC06)
@@ -1126,10 +1126,11 @@ end
 @testitem "#458 CSB exact inequality HVP: FD parity of the weighted residual Hessian" begin
     using NamedTrajectories
 
-    CubicSplineBoundConstraint,
-    constraint_stencil_hvp!,
-    supports_matrix_free_constraint_hvp,
-    evaluate!
+    using Piccolo:
+        CubicSplineBoundConstraint,
+        constraint_stencil_hvp!,
+        supports_matrix_free_constraint_hvp
+    using DirectTrajOpt.CommonInterface: evaluate!
     using ForwardDiff
     using LinearAlgebra
     using Random

--- a/src/control/constraints_spline/cubic_spline_bound_constraint.jl
+++ b/src/control/constraints_spline/cubic_spline_bound_constraint.jl
@@ -1,0 +1,1303 @@
+"""
+    CubicSplineBoundConstraint <: AbstractNonlinearConstraint
+
+Constraint that ensures a cubic Hermite spline stays within bounds at all points
+along the interpolation, not just at knot points.
+
+For each segment between knots k and k+1, the cubic polynomial can have extrema
+at interior points. This constraint finds those extrema and ensures they satisfy bounds.
+
+# Constructor
+```julia
+CubicSplineBoundConstraint(
+    traj::NamedTrajectory,
+    control_name::Symbol,
+    lower_bound::Real,
+    upper_bound::Real;
+    times::Union{Nothing, AbstractVector{Int}}=nothing,
+    n_interior_points::Int=2  # Number of points to check between knots
+)
+```
+
+# Arguments
+- `traj`: NamedTrajectory with cubic spline controls (requires :u and :du components)
+- `control_name`: Name of the control variable (e.g., :u)
+- `lower_bound`: Lower bound for the spline
+- `upper_bound`: Upper bound for the spline
+- `times`: Which knot-point segments to constrain (default: all segments 1:N-1)
+- `n_interior_points`: Number of interior points to check per segment (default: 2)
+
+# Example
+```julia
+# Ensure first control component stays between -1 and 1 along entire spline
+constraint = CubicSplineBoundConstraint(
+    traj, :u, -1.0, 1.0;
+    times=1:traj.N-1
+)
+```
+
+# Representation
+
+The residual and the assembled Jacobian are served from a `ConstraintStencilTable`
+(ADR-0010): one table *functional* per unique scalar sample `s(τ)` the constraint forms,
+its constant columns declared once at construction, and only the coefficients refreshed
+per iterate. Each sample feeds a `±` row pair (`lower - s ≤ 0` and `s - upper ≤ 0`)
+sharing that one scalar, which is the structure `#332`'s matrix-free kernels exploit.
+
+The kernels read the trajectory's flat `datavec` at those precomputed columns through a
+**function barrier** — never `traj[name]`, which is inferred as `Any` and boxes every
+scalar read. That was 1887 µs and megabyte-scale allocation per Jacobian at `N`=801.
+
+**Stencil width 1.** Every row reads a single interval —
+`u_k, u_{k+1}, du_k, du_{k+1}, Δt_k` — so no column lies more than one knot from its
+anchor `k`. The constructor checks that against the declared columns, because the
+declared width is what the sharded backend maximises over and a wrong declaration is
+otherwise silent until multi-rank. Contrast `HermiteSmoothAccelerationConstraint`, whose
+continuity rows couple two adjacent intervals (`k-1, k, k+1`) at the same width.
+
+# Allocation
+
+**Not** zero-allocation, and zero allocation is not the target: the interface hands the
+constraint a `NamedTrajectory` whose `datavec` is an abstractly-typed field, so one
+dynamic access costs a constant floor of ~80 B that no kernel work removes. What is
+guaranteed, and gated, is **knot-flatness** — per-call allocation for `evaluate!` and for
+both Jacobian entry points is independent of the knot count. See ADR-0009 decision 3 and
+ADR-0010 decision 6.
+
+# Notes
+- Requires both :u and :du components in trajectory (cubic Hermite spline DOFs)
+- Checks spline values at uniformly spaced interior points
+- For more accuracy, increase `n_interior_points` (but adds more constraints)
+- `n_interior_points` is a fixed count per segment, so the functional enumeration is
+  static at construction and the table never resizes per iterate
+"""
+struct CubicSplineBoundConstraint <: AbstractNonlinearConstraint
+    control_name::Symbol
+    derivative_name::Symbol
+    timestep_name::Symbol
+    lower_bound::Float64
+    upper_bound::Float64
+    times::Vector{Int}
+    n_interior_points::Int
+    n_drives::Int
+    equality::Bool
+    g_dim::Int
+    dim::Int
+    var_dim::Int
+
+    # Functional-indexed stencil table: the declared structure (constant columns, signed
+    # row map, per-row constant, stencil width) plus the per-iterate coefficients.
+    # Application — sparse fill, cached assembly, row scatter — is generic over it.
+    table::ConstraintStencilTable
+
+    # Per-functional interior-point parameter τ ∈ (0,1). This constraint's analogue of
+    # the smooth-acceleration constraint's `kinds` tag: there is exactly ONE closed-form
+    # functional here (the spline value), parameterised by τ, so the per-functional datum
+    # is a τ rather than a kind enum. The constraint's own math; the table never reads it.
+    τs::Vector{Float64}
+
+    # Jacobian sparsity structure (derived from the table, cached for the interface)
+    jac_structure::Vector{Tuple{Int,Int}}
+
+    # Hessian, declared zero. Exact only while Δt is not a decision variable: the sample
+    # is linear in `u` and `du`, but `∂²s/∂Δt∂du_k = h10(τ) ≠ 0`. That is a PRE-EXISTING
+    # formulation gap, out of scope for #331 (a representation change, not a formulation
+    # change) and recorded in the `eval_hessian_of_lagrangian` docstring below. Sized at
+    # the FULL decision-vector width from the table, so it stacks against a trajectory
+    # carrying globals — the pre-port sizing omitted them.
+    μ∂²g_full::SparseMatrixCSC{Float64,Int}
+end
+
+# Stencil width: one interval per row (`k, k+1`), i.e. no column further than one knot
+# from the anchor. DECLARED, never acted on here — halo exchange belongs to the sharded
+# driver, which takes `max` over dynamics and every routed constraint and exchanges once.
+const CSB_STENCIL_WIDTH = 1
+
+function CubicSplineBoundConstraint(
+    traj::NamedTrajectory,
+    control_name::Symbol = :u,
+    lower_bound::Real = -Inf,
+    upper_bound::Real = Inf;
+    times::Union{Nothing,AbstractVector{Int}} = nothing,
+    n_interior_points::Int = 2,
+)
+    @assert control_name ∈ traj.names "Control $control_name not found in trajectory"
+
+    derivative_name = Symbol(:d, control_name)
+    @assert derivative_name ∈ traj.names "Derivative $derivative_name not found - cubic spline requires both u and du"
+
+    timestep_name = traj.timestep
+    @assert haskey(traj.components, timestep_name) "Trajectory missing timestep component $timestep_name"
+
+    # Default: all segments
+    if isnothing(times)
+        times = collect(1:(traj.N-1))
+    else
+        times = collect(times)
+    end
+
+    @assert !isempty(times) "times is empty — nothing to constrain"
+    @assert all(k -> 1 <= k <= traj.N - 1, times) "times must lie in 1:$(traj.N-1)"
+    @assert n_interior_points >= 1 "n_interior_points must be at least 1, got $n_interior_points"
+
+    n_drives = traj.dims[control_name]
+
+    # For each segment k→k+1, check n_interior_points in each drive
+    # Total constraints: length(times) * n_interior_points * n_drives * 2 (upper and lower)
+    g_dim = length(times) * n_interior_points * n_drives * 2
+
+    # Variable dimension: u and du at two knots per segment
+    var_dim = 2 * n_drives * 2  # (u_k, u_{k+1}, du_k, du_{k+1})
+
+    dim = g_dim
+
+    # Interior sample points, uniformly spaced in τ ∈ (0,1). A FIXED count per segment, so
+    # the functional enumeration below is static: the table needs no per-iterate resizing.
+    # Materialised once here; iterating the range and collecting it give bit-identical
+    # Float64s, which is what lets the residual-parity witness assert `==`.
+    τ_values = collect(range(0.0, 1.0, length = n_interior_points + 2)[2:(end-1)])
+
+    # ── Structure declaration ─────────────────────────────────────────────────────── #
+    #
+    # THE FULL DECISION-VECTOR WIDTH, INCLUDING GLOBALS, carried as data on the table
+    # rather than recomputed at each use site: sizing the Jacobian without the global
+    # columns is what made the backend's row-stacking throw outright on any trajectory
+    # carrying free phases.
+    n_cols = traj.dim * traj.N + traj.global_dim
+    n_knot_cols = traj.dim * traj.N
+    u_comps = traj.components[control_name]
+    du_comps = traj.components[derivative_name]
+    dt_comps = traj.components[timestep_name]
+    u_col = (k, d) -> slice(k, u_comps, traj.dim)[d]
+    du_col = (k, d) -> slice(k, du_comps, traj.dim)[d]
+    dt_col = k -> slice(k, dt_comps, traj.dim)[1]
+
+    lo = Float64(lower_bound)
+    hi = Float64(upper_bound)
+
+    functional_cols = Vector{Vector{Int}}()
+    τs = Float64[]
+    row_map = Int[]
+    row_offset = Float64[]
+
+    # Row order is the pre-port one exactly: segment, then drive, then sample point, and
+    # each sample's LOWER row before its UPPER row. Both rows of a sample are emitted
+    # together, so a functional's rows are CONTIGUOUS by construction — the invariant
+    # `ConstraintStencilTable` enforces.
+    for k in times, d = 1:n_drives, τ in τ_values
+        cols = [u_col(k, d), u_col(k + 1, d), du_col(k, d), du_col(k + 1, d), dt_col(k)]
+
+        # AC6 of #331: the DECLARED stencil width, checked against the declared columns.
+        # Every column must sit within `CSB_STENCIL_WIDTH` knots of the anchor `k`. The
+        # sharded backend takes `max` over dynamics and every routed constraint and
+        # exchanges one halo at that width, so an under-declaration corrupts nothing
+        # locally and everything at multi-rank — it has to be caught here.
+        for c in cols
+            knot = ((c - 1) ÷ traj.dim) + 1
+            @assert c <= n_knot_cols "column $c is not a knot column"
+            @assert abs(knot - k) <= CSB_STENCIL_WIDTH "declared column $c sits $(abs(knot - k)) knots from anchor $k, exceeding the declared stencil width $CSB_STENCIL_WIDTH"
+        end
+
+        push!(functional_cols, cols)
+        push!(τs, τ)
+        f = length(functional_cols)
+        # Lower: `lo - s ≤ 0`  →  sign −1, offset  lo
+        push!(row_map, -f)
+        push!(row_offset, lo)
+        # Upper: `s - hi ≤ 0`  →  sign +1, offset −hi
+        push!(row_map, f)
+        push!(row_offset, -hi)
+    end
+
+    @assert length(row_map) == g_dim "internal: emitted $(length(row_map)) rows, expected $g_dim"
+
+    table = ConstraintStencilTable(
+        functional_cols,
+        row_map,
+        row_offset,
+        n_cols;
+        stencil_width = CSB_STENCIL_WIDTH,
+    )
+
+    μ∂²g_full = spzeros(n_cols, n_cols)
+
+    return CubicSplineBoundConstraint(
+        control_name,
+        derivative_name,
+        timestep_name,
+        lo,
+        hi,
+        times,
+        n_interior_points,
+        n_drives,
+        false,  # inequality constraint (bounds)
+        g_dim,
+        dim,
+        var_dim,
+        table,
+        τs,
+        stencil_structure(table),
+        μ∂²g_full,
+    )
+end
+
+jacobian_structure(c::CubicSplineBoundConstraint) = c.jac_structure
+
+"""
+    stencil_width(constraint::CubicSplineBoundConstraint) -> Int
+
+The declared stencil width: the maximum number of knots either side of its anchor that
+one constraint row reads. 1 here — every row samples a single interval `k → k+1`.
+
+Declared, never acted on: halo exchange belongs to the sharded driver, which takes `max`
+over dynamics and every routed constraint and exchanges once per callback.
+"""
+stencil_width(c::CubicSplineBoundConstraint) = c.table.stencil_width
+
+# ----------------------------------------------------------------------------- #
+# Barrier kernels
+# ----------------------------------------------------------------------------- #
+#
+# `Z` arrives as `traj.datavec`, an abstractly-typed FIELD — reading scalars through it at
+# the call site (or through `traj[name]`, inferred as `Any`) boxes every intermediate and
+# was the bulk of the pre-port allocation. These functions are the FUNCTION BARRIER: one
+# dynamic dispatch at entry, then a fully concrete body. Passing component *views* through
+# a barrier is measurably not sufficient — it leaves a constant kilobyte-scale floor.
+
+"""
+    _csb_residual!(g, Z, τs, table)
+
+Residual barrier: sample the spline at each functional's τ and scatter the value straight
+into its (contiguous) `±` row pair. No per-functional buffer, so this is generic in
+`eltype(g)` / `eltype(Z)` — forward-mode AD of this very function is the Jacobian oracle.
+"""
+function _csb_residual!(
+    g::AbstractVector,
+    Z::AbstractVector,
+    τs::Vector{Float64},
+    table::ConstraintStencilTable,
+)
+    cols = table.cols
+    col_ptr = table.col_ptr
+    @inbounds for f in eachindex(τs)
+        o = col_ptr[f] - 1
+        u_k = Z[cols[o+1]]
+        u_k1 = Z[cols[o+2]]
+        du_k = Z[cols[o+3]]
+        du_k1 = Z[cols[o+4]]
+        Δt = Z[cols[o+5]]
+        val = evaluate_hermite_spline(τs[f], u_k, u_k1, du_k, du_k1, Δt)
+        stencil_scatter_functional!(g, table, f, val)
+    end
+    return nothing
+end
+
+"""
+    _csb_refresh_coefficients!(Z, τs, table)
+
+Per-iterate coefficient refresh: overwrite `table.coeffs` with ∂s/∂column, in the declared
+column order `(u_k, u_{k+1}, du_k, du_{k+1}, Δt_k)`. The `±` row signs and the per-row
+bound offsets are the table's business, not this kernel's.
+"""
+function _csb_refresh_coefficients!(
+    Z::AbstractVector,
+    τs::Vector{Float64},
+    table::ConstraintStencilTable,
+)
+    cols = table.cols
+    col_ptr = table.col_ptr
+    coeffs = table.coeffs
+    @inbounds for f in eachindex(τs)
+        o = col_ptr[f] - 1
+        du_k = Z[cols[o+3]]
+        du_k1 = Z[cols[o+4]]
+        Δt = Z[cols[o+5]]
+        ∂u_k, ∂u_k1, ∂du_k, ∂du_k1, ∂Δt = hermite_value_gradient(du_k, du_k1, Δt, τs[f])
+        coeffs[o+1] = ∂u_k
+        coeffs[o+2] = ∂u_k1
+        coeffs[o+3] = ∂du_k
+        coeffs[o+4] = ∂du_k1
+        coeffs[o+5] = ∂Δt
+    end
+    stencil_touch!(table)
+    return nothing
+end
+
+# ── The constraint-type gradient trait (#332) ─────────────────────────────────── #
+#
+# Two methods, and `supports_matrix_free_constraint_gradient` follows from them: this
+# constraint declares a bounded stencil width (one interval per row), so the backend's
+# inequality path serves its rows from `stencil_jvp!` / `stencil_vjp!` and gives it no
+# block in the assembled matrix. `eval_jacobian` above is untouched and stays the
+# assembled contract for Ipopt/MadNLP.
+
+constraint_stencil_table(c::CubicSplineBoundConstraint) = c.table
+
+refresh_constraint_coefficients!(c::CubicSplineBoundConstraint, traj::NamedTrajectory) =
+    _csb_refresh_coefficients!(traj.datavec, c.τs, c.table)
+
+# ----------------------------------------------------------------------------- #
+# DirectTrajOpt interface — three-line wrappers over the barriers
+# ----------------------------------------------------------------------------- #
+
+"""
+    evaluate!(values, constraint, traj)
+
+Evaluate the interior-sample bounds as pure inequalities (≤ 0), two rows per sample:
+`lower - s(τ) ≤ 0` and `s(τ) - upper ≤ 0`.
+"""
+function CommonInterface.evaluate!(
+    values::AbstractVector,
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+)
+    _csb_residual!(values, traj.datavec, constraint.τs, constraint.table)
+    return nothing
+end
+
+"""
+    jacobian!(jac, constraint, traj)
+
+Compute the Jacobian's nonzero values, in `jacobian_structure` order.
+"""
+function jacobian!(
+    jac::AbstractVector,
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+)
+    _csb_refresh_coefficients!(traj.datavec, constraint.τs, constraint.table)
+    stencil_fill_values!(jac, constraint.table)
+    return nothing
+end
+
+"""
+    jacobian!(constraint, traj)
+
+Refresh the cached assembled Jacobian in place (the pre-port two-argument form; the
+matrix is then read from `get_full_jacobian` / `eval_jacobian`).
+"""
+function jacobian!(constraint::CubicSplineBoundConstraint, traj::NamedTrajectory)
+    _csb_refresh_coefficients!(traj.datavec, constraint.τs, constraint.table)
+    stencil_assemble!(constraint.table)
+    return nothing
+end
+
+function DirectTrajOpt.Constraints.get_full_jacobian(
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+)
+    _csb_refresh_coefficients!(traj.datavec, constraint.τs, constraint.table)
+    return stencil_assemble!(constraint.table)
+end
+
+"""
+    eval_jacobian(constraint, traj) -> SparseMatrixCSC
+
+The ASSEMBLED Jacobian entry point — unchanged in contract (this is what Ipopt/MadNLP and
+the backend's row-stacking consume). Served from the stencil table's cached sparse matrix:
+the pattern is built once at construction and only `nzval` is refreshed, so the returned
+matrix is the same object on every call and the call allocates nothing that grows with the
+knot count.
+
+`size(J) == (g_dim, traj.dim * traj.N + traj.global_dim)` — the FULL decision-vector
+width. Sizing it without the global columns made the row-stacking throw on any trajectory
+carrying free phases.
+"""
+function eval_jacobian(constraint::CubicSplineBoundConstraint, traj::NamedTrajectory)
+    _csb_refresh_coefficients!(traj.datavec, constraint.τs, constraint.table)
+    return stencil_assemble!(constraint.table)
+end
+
+function hessian_of_lagrangian!(
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    return nothing
+end
+
+function DirectTrajOpt.Constraints.get_full_hessian(
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    return constraint.μ∂²g_full
+end
+
+"""
+    eval_hessian_of_lagrangian(constraint, traj, μ) -> SparseMatrixCSC
+
+Declared zero, at the full decision-vector width.
+
+The sample `s(τ) = h00·u_k + h10·Δt·du_k + h01·u_{k+1} + h11·Δt·du_{k+1}` is linear in
+`u` and `du`, so with a FIXED timestep the Hessian really is zero. With `Δt` a decision
+variable it is not: `∂²s/∂Δt∂du_k = h10(τ)`. That gap is inherited from the pre-port
+implementation and deliberately left alone — #331 is a representation change, not a
+formulation change — and is the same class of issue as the `CubicSplineExtremaConstraint`
+discontinuity recorded in ADR-0010's consequences.
+"""
+function CommonInterface.eval_hessian_of_lagrangian(
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    return constraint.μ∂²g_full
+end
+
+# ============================================================================= #
+#   Reference (pre-port) residual and Jacobian — the semantics witnesses         #
+# ============================================================================= #
+#
+# Kept reachable so the port can be checked against the implementation it replaces, on
+# randomised trajectories (#331 AC1/AC5). Both read the trajectory through the
+# named-component accessor exactly as the pre-port code did — which is why they are
+# test-only and on no hot path.
+
+"""
+    _csb_reference_evaluate!(values, constraint, traj)
+
+The pre-port residual, verbatim in formulation and row order. Test-only witness for
+"residual semantics unchanged".
+"""
+function _csb_reference_evaluate!(
+    values::AbstractVector,
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+)
+    u = traj[constraint.control_name]
+    du = traj[constraint.derivative_name]
+    Δt = traj[constraint.timestep_name]
+
+    constraint_idx = 1
+
+    for k in constraint.times
+        k_next = k + 1
+        Δt_k = Δt[k]
+
+        τ_values = range(0.0, 1.0, length = constraint.n_interior_points + 2)[2:(end-1)]
+
+        for drive_idx = 1:constraint.n_drives
+            u_k = u[drive_idx, k]
+            u_k1 = u[drive_idx, k_next]
+            du_k = du[drive_idx, k]
+            du_k1 = du[drive_idx, k_next]
+
+            for τ in τ_values
+                s = evaluate_hermite_spline(τ, u_k, u_k1, du_k, du_k1, Δt_k)
+
+                # Lower bound: lower_bound ≤ s  →  lower_bound - s ≤ 0
+                values[constraint_idx] = constraint.lower_bound - s
+                constraint_idx += 1
+
+                # Upper bound: s ≤ upper_bound  →  s - upper_bound ≤ 0
+                values[constraint_idx] = s - constraint.upper_bound
+                constraint_idx += 1
+            end
+        end
+    end
+
+    return nothing
+end
+
+"""
+    _csb_reference_jacobian(constraint, traj) -> SparseMatrixCSC
+
+The pre-port assembled Jacobian, verbatim: built fresh, at the pre-port width
+`traj.dim * traj.N` (which is exactly the sizing bug — the global columns are missing).
+Test-only witness for "the assembled entry point is numerically identical".
+"""
+function _csb_reference_jacobian(
+    constraint::CubicSplineBoundConstraint,
+    traj::NamedTrajectory,
+)
+    du = traj[constraint.derivative_name]
+    Δt = traj[constraint.timestep_name]
+
+    I_rows = Int[]
+    J_cols = Int[]
+    V = Float64[]
+    constraint_idx = 1
+
+    for k in constraint.times
+        k_next = k + 1
+        Δt_k = Δt[k]
+
+        τ_values = range(0.0, 1.0, length = constraint.n_interior_points + 2)[2:(end-1)]
+
+        u_k_slice = slice(k, traj.components[constraint.control_name], traj.dim)
+        u_k1_slice = slice(k_next, traj.components[constraint.control_name], traj.dim)
+        du_k_slice = slice(k, traj.components[constraint.derivative_name], traj.dim)
+        du_k1_slice = slice(k_next, traj.components[constraint.derivative_name], traj.dim)
+        Δt_k_idx = slice(k, traj.components[constraint.timestep_name], traj.dim)[1]
+
+        for drive_idx = 1:constraint.n_drives
+            var_idxs = [
+                u_k_slice[drive_idx],
+                u_k1_slice[drive_idx],
+                du_k_slice[drive_idx],
+                du_k1_slice[drive_idx],
+                Δt_k_idx,
+            ]
+            du_k_val = du[drive_idx, k]
+            du_k1_val = du[drive_idx, k_next]
+
+            for τ in τ_values
+                # The body of the retired `eval_cubic_hermite_jacobian`, written out here
+                # ON PURPOSE: this is the pre-port witness, and calling the shared
+                # `hermite_value_gradient` (which the port itself calls) would stop it
+                # witnessing the coefficient transcription. Not an AC7 duplication —
+                # nothing on a hot path reaches it.
+                h00, h10, h01, h11 = hermite_basis_functions(τ)
+                ∂s = [h00, h01, Δt_k * h10, Δt_k * h11, h10 * du_k_val + h11 * du_k1_val]
+
+                for (j, v) in zip(var_idxs, ∂s)          # lower: ∂g/∂x = -∂s/∂x
+                    push!(I_rows, constraint_idx)
+                    push!(J_cols, j)
+                    push!(V, -v)
+                end
+                constraint_idx += 1
+
+                for (j, v) in zip(var_idxs, ∂s)          # upper: ∂g/∂x = +∂s/∂x
+                    push!(I_rows, constraint_idx)
+                    push!(J_cols, j)
+                    push!(V, v)
+                end
+                constraint_idx += 1
+            end
+        end
+    end
+
+    return sparse(I_rows, J_cols, V, constraint.g_dim, traj.dim * traj.N)
+end
+
+# ============================================================================= #
+# Tests
+# ============================================================================= #
+
+@testitem "CubicSplineBoundConstraint - basic construction" begin
+    using NamedTrajectories
+    using Piccolo
+
+    N = 10
+    n_drives = 2
+
+    # Create trajectory with cubic spline components
+    traj = NamedTrajectory(
+        (
+            x = randn(3, N),
+            u = randn(n_drives, N),
+            du = randn(n_drives, N),
+            Δt = fill(0.1, N),
+        );
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Create constraint
+    constraint = CubicSplineBoundConstraint(traj, :u, -1.0, 1.0)
+
+    @test constraint isa CubicSplineBoundConstraint
+    @test constraint.control_name == :u
+    @test constraint.derivative_name == :du
+    @test constraint.lower_bound == -1.0
+    @test constraint.upper_bound == 1.0
+    @test constraint.n_drives == n_drives
+    @test constraint.times == collect(1:(N-1))
+    @test constraint.n_interior_points == 2  # default
+
+    # Check constraint dimensions
+    # Each segment has n_interior_points * n_drives * 2 (lower+upper) constraints
+    expected_dim = (N-1) * 2 * n_drives * 2
+    @test constraint.g_dim == expected_dim
+    @test constraint.dim == expected_dim
+end
+
+@testitem "CubicSplineBoundConstraint - custom times and interior points" begin
+    using NamedTrajectories
+    using Piccolo
+
+    N = 20
+    traj = NamedTrajectory(
+        (u = randn(1, N), du = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Custom settings
+    times = 5:15
+    n_interior = 3
+    constraint = CubicSplineBoundConstraint(
+        traj,
+        :u,
+        -2.0,
+        2.0;
+        times = times,
+        n_interior_points = n_interior,
+    )
+
+    @test constraint.times == collect(times)
+    @test constraint.n_interior_points == n_interior
+    @test constraint.g_dim == length(times) * n_interior * 1 * 2
+end
+
+@testitem "CubicSplineBoundConstraint - evaluation" begin
+    using NamedTrajectories
+    using Piccolo
+    using LinearAlgebra
+
+    N = 5
+    n_drives = 1
+
+    # Create simple trajectory with known values
+    u = [0.0 0.5 1.0 0.5 0.0]  # 1×5 matrix
+    du = [1.0 0.0 -1.0 -1.0 0.0]  # derivatives
+    Δt_vec = fill(0.2, N)
+
+    traj = NamedTrajectory(
+        (u = u, du = du, Δt = reshape(Δt_vec, 1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Bounds that should be satisfied
+    constraint = CubicSplineBoundConstraint(traj, :u, -0.5, 1.5; n_interior_points = 3)
+
+    values = zeros(constraint.g_dim)
+    evaluate!(values, constraint, traj)
+
+    # All constraints should be satisfied (≤ 0 for inequality constraints)
+    # Lower bound: lower - s ≤ 0  →  s ≥ lower
+    # Upper bound: s - upper ≤ 0  →  s ≤ upper
+    @test length(values) == constraint.g_dim
+
+    # With bounds [-0.5, 1.5] and max control at 1.0, all should be feasible
+    # Check a few constraints are within reasonable range
+    @test all(isfinite.(values))
+end
+
+@testitem "CubicSplineBoundConstraint - detects violations" begin
+    using NamedTrajectories
+    using Piccolo
+
+    N = 5
+
+    # Create trajectory that will violate bounds at interior points
+    # Use knot points that are within bounds but derivatives create overshoot
+    u = [0.0 0.1 0.0 0.1 0.0]  # Oscillating but within [-0.2, 0.2]
+    du = [2.0 -2.0 2.0 -2.0 0.0]  # Large opposing derivatives cause overshoot
+    Δt_vec = fill(0.2, N)
+
+    traj = NamedTrajectory(
+        (u = u, du = du, Δt = reshape(Δt_vec, 1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Very tight bounds - the cubic interpolation will overshoot these
+    constraint = CubicSplineBoundConstraint(traj, :u, -0.15, 0.15; n_interior_points = 5)
+
+    values = zeros(constraint.g_dim)
+    evaluate!(values, constraint, traj)
+
+    # Should have violations (positive constraint values)
+    # The Hermite spline with large opposing derivatives will exceed bounds
+    @test any(values .> 1e-6)  # Use tolerance to avoid numerical issues
+end
+
+@testitem "CubicSplineBoundConstraint - jacobian correctness" begin
+    using NamedTrajectories
+    using Piccolo
+    using FiniteDiff
+    using SparseArrays
+    using LinearAlgebra
+
+    N = 6
+    n_drives = 2
+
+    traj = NamedTrajectory(
+        (u = 0.1 * randn(n_drives, N), du = 0.1 * randn(n_drives, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    constraint = CubicSplineBoundConstraint(
+        traj,
+        :u,
+        -1.0,
+        1.0;
+        times = 2:(N-2),  # Test subset
+        n_interior_points = 2,
+    )
+
+    # Function to evaluate constraints
+    g_func = Z -> begin
+        test_traj = NamedTrajectory(traj; datavec = Z)
+        vals = zeros(constraint.g_dim)
+        evaluate!(vals, constraint, test_traj)
+        return vals
+    end
+
+    # Analytical Jacobian
+    ∂g_analytical = Matrix(eval_jacobian(constraint, traj))
+
+    # Finite difference Jacobian
+    Z = copy(traj.datavec)
+    ∂g_fd = FiniteDiff.finite_difference_jacobian(g_func, Z)
+
+    # Check they match
+    rel_error = norm(∂g_analytical - ∂g_fd) / (norm(∂g_fd) + 1e-10)
+    @test rel_error < 1e-5
+end
+
+@testitem "CubicSplineBoundConstraint - multiple drives" begin
+    using NamedTrajectories
+    using Piccolo
+    using SparseArrays
+
+    N = 8
+    n_drives = 3
+
+    traj = NamedTrajectory(
+        (u = randn(n_drives, N), du = randn(n_drives, N), Δt = fill(0.15, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    constraint = CubicSplineBoundConstraint(traj, :u, -2.0, 2.0; n_interior_points = 3)
+
+    # Check dimensions scale correctly with number of drives
+    expected_constraints = (N-1) * 3 * n_drives * 2
+    @test constraint.g_dim == expected_constraints
+
+    # Evaluate and check structure
+    values = zeros(constraint.g_dim)
+    evaluate!(values, constraint, traj)
+
+    @test length(values) == expected_constraints
+    @test all(isfinite.(values))
+
+    # Check Jacobian sparsity
+    J = eval_jacobian(constraint, traj)
+    @test nnz(J) > 0
+    @test size(J) == (constraint.g_dim, traj.dim * N + traj.global_dim)
+end
+
+@testitem "CubicSplineBoundConstraint - hermite evaluation accuracy" begin
+    # AC7 of #331: this testitem used to define its own copies of the four Hermite basis
+    # polynomials and of the value gradient, so it tested those copies and nothing in the
+    # library. It now exercises the CONSOLIDATED primitives — which is what the constraint
+    # itself calls.
+    using Piccolo: evaluate_hermite_spline, hermite_value_gradient
+    using ForwardDiff
+
+    u_k = 0.0
+    u_k1 = 1.0
+    du_k = 0.5
+    du_k1 = -0.5
+    Δt = 0.1
+
+    # At τ=0, should equal u_k; at τ=1, u_k1
+    @test evaluate_hermite_spline(0.0, u_k, u_k1, du_k, du_k1, Δt) ≈ u_k
+    @test evaluate_hermite_spline(1.0, u_k, u_k1, du_k, du_k1, Δt) ≈ u_k1
+
+    # Value gradient at the segment boundaries, in the constraint's declared column order
+    # (u_k, u_{k+1}, du_k, du_{k+1}, Δt).
+    ∂s0 = hermite_value_gradient(du_k, du_k1, Δt, 0.0)
+    @test ∂s0[1] ≈ 1.0  # ∂s/∂u_k at τ=0
+    @test ∂s0[2] ≈ 0.0  # ∂s/∂u_k1 at τ=0
+
+    ∂s1 = hermite_value_gradient(du_k, du_k1, Δt, 1.0)
+    @test ∂s1[1] ≈ 0.0  # ∂s/∂u_k at τ=1
+    @test ∂s1[2] ≈ 1.0  # ∂s/∂u_k1 at τ=1
+
+    # …and the gradient IS the gradient of the value, including the Δt partial that the
+    # retired `eval_cubic_hermite_jacobian` copy never checked.
+    for τ in (0.0, 0.25, 0.5, 0.75, 1.0)
+        ad = ForwardDiff.gradient(
+            v -> evaluate_hermite_spline(τ, v[1], v[2], v[3], v[4], v[5]),
+            [u_k, u_k1, du_k, du_k1, Δt],
+        )
+        @test all(isapprox.(collect(hermite_value_gradient(du_k, du_k1, Δt, τ)), ad))
+    end
+end
+
+@testitem "#331 AC1/AC2/AC5: ported residual matches the reference; Jacobian matches forward-mode AD" begin
+    using NamedTrajectories
+
+    CubicSplineBoundConstraint,
+    evaluate!,
+    jacobian!,
+    jacobian_structure,
+    eval_jacobian,
+    get_full_jacobian,
+    _csb_reference_evaluate!,
+    _csb_reference_jacobian
+    using ForwardDiff
+    using SparseArrays
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(0x331AC12)
+
+    # Trajectory factory, with and without global variables. The globals case is the one
+    # that matters for the DERIVATIVE oracle — the pre-port implementation sized its
+    # Jacobian without the global columns, so parity against it proves nothing there.
+    # Forward-mode AD OF THE PORTED RESIDUAL is the oracle: everything here is closed
+    # form, so a tolerance loose enough to absorb finite-difference truncation error is
+    # loose enough to hide a wrong stencil coefficient.
+    function fixture(N, n_drives; globals::Bool, n_interior = 2, times = nothing)
+        comps = (
+            u = randn(n_drives, N),
+            du = randn(n_drives, N) * 0.5,
+            Δt = reshape(0.05 .+ 0.1 .* rand(N), 1, N),
+        )
+        traj =
+            globals ?
+            NamedTrajectory(
+                comps;
+                timestep = :Δt,
+                controls = :u,
+                global_data = [0.3, -0.8],
+                global_components = (ϕ = 1:2,),
+            ) : NamedTrajectory(comps; timestep = :Δt, controls = :u)
+        c = CubicSplineBoundConstraint(
+            traj,
+            :u,
+            -0.9,
+            1.1;
+            n_interior_points = n_interior,
+            times = times,
+        )
+        return traj, c
+    end
+
+    # ── AC1: residual semantics unchanged, to machine precision, on randomised
+    # trajectories. The reference is the pre-port implementation, kept reachable.
+    for trial = 1:5
+        N = rand(4:9)
+        nd = rand(1:3)
+        ni = rand(1:4)                        # includes the non-default interior counts
+        traj, c = fixture(N, nd; globals = false, n_interior = ni)
+        g_new = zeros(c.g_dim)
+        g_ref = zeros(c.g_dim)
+        evaluate!(g_new, c, traj)
+        _csb_reference_evaluate!(g_ref, c, traj)
+        @test g_new == g_ref        # bit-identical: same formulation, same row order
+    end
+
+    # Same, with globals present (neither the formulation nor the reference reads them),
+    # and on a subset of segments.
+    for fx in (
+        fixture(7, 2; globals = true, n_interior = 3),
+        fixture(9, 2; globals = false, n_interior = 5, times = 3:6),
+    )
+        traj, c = fx
+        g_new = zeros(c.g_dim)
+        g_ref = zeros(c.g_dim)
+        evaluate!(g_new, c, traj)
+        _csb_reference_evaluate!(g_ref, c, traj)
+        @test g_new == g_ref
+    end
+
+    # ── AC2: the assembled Jacobian matches forward-mode AD of the ported residual.
+    function ad_jacobian(traj, c)
+        n_data = traj.dim * traj.N
+        f =
+            Z -> begin
+                t = NamedTrajectory(
+                    traj;
+                    datavec = Z[1:n_data],
+                    global_data = Z[(n_data+1):end],
+                )
+                g = zeros(eltype(Z), c.g_dim)
+                evaluate!(g, c, t)
+                return g
+            end
+        return ForwardDiff.jacobian(f, collect(vec(traj)))
+    end
+
+    for (label, fx) in (
+        "no globals" => fixture(8, 2; globals = false),
+        "with globals" => fixture(8, 2; globals = true),
+        "non-default interior count" => fixture(8, 2; globals = true, n_interior = 5),
+        "segment subset" => fixture(10, 3; globals = true, times = 4:8),
+        "single interior point" => fixture(6, 1; globals = false, n_interior = 1),
+    )
+        traj, c = fx
+        J = eval_jacobian(c, traj)
+        J_ad = ad_jacobian(traj, c)
+        @test size(J) == size(J_ad)      # includes the global columns
+        @test size(J, 2) == traj.dim * traj.N + traj.global_dim
+        @test maximum(abs, Matrix(J) - J_ad) < 1e-12 * max(1.0, maximum(abs, J_ad))
+
+        # The flat-value entry point agrees with the assembled one, entry for entry.
+        vals = zeros(length(jacobian_structure(c)))
+        jacobian!(vals, c, traj)
+        for (e, (r, col)) in enumerate(jacobian_structure(c))
+            @test vals[e] == J[r, col]
+        end
+    end
+
+    # ── AC5: the assembled entry point is still there and NUMERICALLY IDENTICAL to the
+    # pre-port one, which is rebuilt from scratch here the way the pre-port code did.
+    for (label, fx) in (
+        "no globals" => fixture(9, 2; globals = false, n_interior = 3),
+        "with globals" => fixture(9, 2; globals = true, n_interior = 3),
+        "segment subset" => fixture(11, 2; globals = false, n_interior = 2, times = 2:9),
+    )
+        traj, c = fx
+        J = eval_jacobian(c, traj)
+        J_ref = _csb_reference_jacobian(c, traj)
+        n_data = traj.dim * traj.N
+        @test size(J_ref) == (c.g_dim, n_data)                 # the pre-port width
+        @test Matrix(J[:, 1:n_data]) == Matrix(J_ref)          # bit-identical values
+        # …and the columns the pre-port sizing dropped are structurally absent, so the
+        # only difference is that the block now stacks against a globals trajectory.
+        @test iszero(J[:, (n_data+1):end])
+
+        # A CACHED reference refilled in place: same object every call, and the two
+        # assembled entry points return that same object.
+        @test eval_jacobian(c, traj) === J
+        @test get_full_jacobian(c, traj) === J
+        @test J === c.table.J
+    end
+end
+
+@testitem "#331 AC3: residual and Jacobian allocation are invariant to knot count" begin
+    using NamedTrajectories
+
+    CubicSplineBoundConstraint, evaluate!, jacobian!, eval_jacobian
+    using Random
+
+    # KNOT-FLATNESS, not zero allocation. The interface hands the constraint a trajectory
+    # whose `datavec` is an abstractly-typed field, so one dynamic access costs a constant
+    # floor no kernel work removes (ADR-0010 decision 6). What is asserted is that the
+    # floor is CONSTANT: an implementation that still reads the trajectory through the
+    # `Any`-inferred accessor, allocates a five-element gradient vector per sample point,
+    # or rebuilds a whole sparse matrix per call, grows linearly in N and fails the `==`.
+    #
+    # Shape copied from #330's gate: local-scoped closures only (a callback at global
+    # scope captures `Any` and inflates the count), and the MINIMUM over repeats because
+    # `@allocated` sums across every thread in the process.
+    function measure(N)
+        Random.seed!(0x331A11C)
+        n_drives = 2
+        traj = NamedTrajectory(
+            (
+                u = randn(n_drives, N),
+                du = randn(n_drives, N),
+                Δt = reshape(fill(0.1, N), 1, N),
+            );
+            timestep = :Δt,
+            controls = :u,
+        )
+        c = CubicSplineBoundConstraint(traj, :u, -1.0, 1.0; n_interior_points = 3)
+        g = zeros(c.g_dim)
+        vals = zeros(length(c.jac_structure))
+        res = () -> evaluate!(g, c, traj)
+        jacv = () -> jacobian!(vals, c, traj)
+        asm = () -> eval_jacobian(c, traj)
+        best = f -> (f(); f(); minimum(@allocated(f()) for _ = 1:5))
+        return (residual = best(res), jacobian = best(jacv), assembled = best(asm))
+    end
+
+    N_SMALL, N_LARGE = 33, 129
+
+    # Process-level warmup over BOTH sizes before either is measured: the FIRST
+    # `@allocated` site in a process reports a different figure from every subsequent one,
+    # and with `==` as the assertion whichever size went first would otherwise carry that
+    # one-time step as phantom N-growth.
+    measure(N_SMALL)
+    measure(N_LARGE)
+
+    a = measure(N_SMALL)
+    b = measure(N_LARGE)
+
+    for k in (:residual, :jacobian, :assembled)
+        # INVARIANCE, not "less than before": a bound of that form is satisfied by an
+        # implementation that still allocates linearly in N.
+        @test getproperty(b, k) == getproperty(a, k)
+        # …plus a loose absolute ceiling, so the constant floor cannot creep either.
+        @test getproperty(b, k) <= 4096
+    end
+end
+
+@testitem "#331 AC6: declared stencil width of one, and the declared structure it implies" begin
+    using NamedTrajectories
+
+    CubicSplineBoundConstraint,
+    eval_jacobian,
+    stencil_width,
+    stencil_coeff_range,
+    stencil_functional_rows,
+    hermite_value_gradient
+    using Random
+
+    Random.seed!(0x331AC06)
+
+    # A non-default interior-point count, because the functional count scales with it.
+    N, n_drives, n_interior = 8, 2, 4
+    times = 2:6
+    traj = NamedTrajectory(
+        (
+            u = randn(n_drives, N),
+            du = 0.5 * randn(n_drives, N),
+            Δt = reshape(0.05 .+ 0.1 .* rand(N), 1, N),
+        );
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.7],
+        global_components = (ϕ = 1:1,),
+    )
+    c = CubicSplineBoundConstraint(
+        traj,
+        :u,
+        -0.8,
+        1.3;
+        times = times,
+        n_interior_points = n_interior,
+    )
+
+    # ── The declaration itself. ONE, because every row samples a single interval — unlike
+    # the smooth-acceleration constraint's continuity rows, which couple two adjacent
+    # intervals. The sharded backend takes `max` over dynamics and every routed
+    # constraint, so an under-declaration is silent locally and wrong at multi-rank; this
+    # is the only place it can be caught cheaply.
+    @test c.table.stencil_width == 1
+    @test stencil_width(c) == 1
+
+    # ── …and the declaration is CONSISTENT with the declared columns: every column of
+    # every functional sits within `stencil_width` knots of that functional's anchor. This
+    # is the assertion that a wrong declaration would fail, as opposed to merely reading
+    # the field back.
+    t = c.table
+    for (f, k) in
+        enumerate(Iterators.flatten(fill(k, n_drives * n_interior) for k in times))
+        knots = [((col - 1) ÷ traj.dim) + 1 for col in t.cols[stencil_coeff_range(t, f)]]
+        @test minimum(knots) == k && maximum(knots) == k + 1
+        @test maximum(abs.(knots .- k)) <= stencil_width(c)
+    end
+
+    # ── Functional enumeration is static and scales with the interior-point count; each
+    # functional is read by exactly one `±` row pair sharing its scalar.
+    n_functionals = length(times) * n_drives * n_interior
+    @test t.n_functionals == n_functionals
+    @test t.n_rows == c.g_dim == 2 * n_functionals
+    @test t.n_cols == traj.dim * traj.N + traj.global_dim
+    for f = 1:n_functionals
+        rows = stencil_functional_rows(t, f)
+        # `2 * f`, never `2f`: the formatter tightens `(2f - 1)` to `2f-1`, which re-lexes
+        # as the Float32 literal 0.2f0 and silently turns this into a nonsense range.
+        @test rows == (2*f-1):(2*f)
+        @test t.row_sign[rows[1]] == -1.0 && t.row_offset[rows[1]] == -0.8   # lower - s
+        @test t.row_sign[rows[2]] == +1.0 && t.row_offset[rows[2]] == -1.3   # s - upper
+    end
+
+    # ── The COEFFICIENTS are this constraint's own math, so check them directly against
+    # the shared Hermite primitive rather than only through the assembled matrix.
+    eval_jacobian(c, traj)                   # refreshes `t.coeffs`
+    u_c, du_c, dt_c = traj.components[:u], traj.components[:du], traj.components[:Δt]
+    # A `Ref`, not `f = 0` + `f += 1`: at top level inside a `for`, `f += 1` binds a NEW
+    # local and throws an UndefVarError.
+    fref = Ref(0)
+    for k in times, d = 1:n_drives, i = 1:n_interior
+        fref[] += 1
+        f = fref[]
+        τ = collect(range(0.0, 1.0, length = n_interior + 2)[2:(end-1)])[i]
+        expected = hermite_value_gradient(
+            traj.datavec[(k-1)*traj.dim+du_c[d]],
+            traj.datavec[k*traj.dim+du_c[d]],
+            traj.datavec[(k-1)*traj.dim+dt_c[1]],
+            τ,
+        )
+        @test t.coeffs[stencil_coeff_range(t, f)] == collect(expected)
+        # …and the columns they sit against are the declared ones, in order.
+        @test t.cols[stencil_coeff_range(t, f)] == [
+            (k - 1) * traj.dim + u_c[d],
+            k * traj.dim + u_c[d],
+            (k - 1) * traj.dim + du_c[d],
+            k * traj.dim + du_c[d],
+            (k - 1) * traj.dim + dt_c[1],
+        ]
+    end
+    @test fref[] == n_functionals
+end
+
+@testitem "#458 CSB exact inequality HVP: FD parity of the weighted residual Hessian" begin
+    using NamedTrajectories
+
+    CubicSplineBoundConstraint,
+    constraint_stencil_hvp!,
+    supports_matrix_free_constraint_hvp,
+    evaluate!
+    using ForwardDiff
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(0x45800B1)
+
+    function fixture(N, n_drives; globals::Bool, n_interior = 2, times = nothing)
+        comps = (
+            u = randn(n_drives, N),
+            du = randn(n_drives, N) * 0.5,
+            Δt = reshape(0.05 .+ 0.1 .* rand(N), 1, N),
+        )
+        traj =
+            globals ?
+            NamedTrajectory(
+                comps;
+                timestep = :Δt,
+                controls = :u,
+                global_data = [0.3, -0.8],
+                global_components = (ϕ = 1:2,),
+            ) : NamedTrajectory(comps; timestep = :Δt, controls = :u)
+        c = CubicSplineBoundConstraint(
+            traj,
+            :u,
+            -0.9,
+            1.1;
+            n_interior_points = n_interior,
+            times = times,
+        )
+        return traj, c
+    end
+
+    function oracle(traj, c, w, v)
+        n_data = traj.dim * traj.N
+        n_vars = n_data + traj.global_dim
+        gfunc =
+            Z -> begin
+                t = NamedTrajectory(
+                    traj;
+                    datavec = Z[1:n_data],
+                    global_data = Z[(n_data+1):end],
+                )
+                g = zeros(eltype(Z), c.g_dim)
+                evaluate!(g, c, t)
+                return dot(w, g)
+            end
+        x = collect(vec(traj))
+        return ForwardDiff.hessian(gfunc, x) * v, x, n_vars
+    end
+
+    for (label, fx) in (
+        "no globals" => fixture(8, 2; globals = false),
+        "with globals" => fixture(8, 2; globals = true),
+        "non-default interior count" => fixture(8, 2; globals = true, n_interior = 4),
+        "segment subset" => fixture(10, 3; globals = true, times = 4:8),
+    )
+        traj, c = fx
+        @test supports_matrix_free_constraint_hvp(c) == true
+
+        w = randn(MersenneTwister(0x458D), c.g_dim)
+        n_vars = traj.dim * traj.N + traj.global_dim
+        v = randn(MersenneTwister(0x458E), n_vars)
+        Hv_ref, x, _ = oracle(traj, c, w, v)
+
+        # The action matches the exact Hessian of the weighted residual — INCLUDING the
+        # Δt/du cross terms the assembled entry point still declares zero (the documented
+        # gap; the matrix-free slot is where it closes).
+        Hv = zeros(n_vars)
+        constraint_stencil_hvp!(Hv, c, w, v, x)
+        @test norm(Hv) > 0
+        @test norm(Hv - Hv_ref) <= 1e-9 * max(1.0, norm(Hv_ref))
+
+        # SUPPORT: the only columns the action can touch are the Δt and du columns of
+        # each functional's segment — assert a v supported purely on the u columns gets
+        # exactly zero everywhere (bilinearity: s has no u² term).
+        v_u_only = zeros(n_vars)
+        u_comps = traj.components[:u]
+        for k = 1:traj.N, d = 1:size(traj[:u], 1)
+            v_u_only[(k-1)*traj.dim+u_comps[d]] = 1.0
+        end
+        Hv_u = zeros(n_vars)
+        constraint_stencil_hvp!(Hv_u, c, w, v_u_only, x)
+        @test all(iszero, Hv_u)
+
+        # ACCUMULATES + balanced ± pairs cancel exactly (every functional is a `±` pair).
+        constraint_stencil_hvp!(Hv, c, w, v, x)
+        @test norm(Hv - 2.0 .* Hv_ref) <= 1e-9 * max(1.0, norm(Hv_ref))
+        w_bal = fill(0.4, c.g_dim)
+        Hv_bal = zeros(n_vars)
+        constraint_stencil_hvp!(Hv_bal, c, w_bal, v, x)
+        @test all(iszero, Hv_bal)
+    end
+end
+
+@testitem "#458 CSB inequality HVP: allocation is invariant to knot count" begin
+    using NamedTrajectories
+    using Piccolo: CubicSplineBoundConstraint, constraint_stencil_hvp!
+    using Random
+
+    function measure(N)
+        Random.seed!(0x45800B2)
+        n_drives = 2
+        traj = NamedTrajectory(
+            (
+                u = randn(n_drives, N),
+                du = randn(n_drives, N),
+                Δt = reshape(fill(0.1, N), 1, N),
+            );
+            timestep = :Δt,
+            controls = :u,
+        )
+        c = CubicSplineBoundConstraint(traj, :u, -1.0, 1.0; n_interior_points = 3)
+        n_vars = traj.dim * traj.N + traj.global_dim
+        Hv = zeros(n_vars)
+        w = randn(c.g_dim)
+        v = randn(n_vars)
+        x = collect(vec(traj))
+        f = () -> constraint_stencil_hvp!(Hv, c, w, v, x)
+        f()
+        f()
+        return minimum(@allocated(f()) for _ = 1:5)
+    end
+
+    measure(33)
+    measure(129)
+    a = measure(33)
+    b = measure(129)
+    # KNOT-FLATNESS, invariance + loose ceiling (ADR-0009 decision 3 / ADR-0010 decision 6).
+    @test b == a
+    @test b <= 4096
+end
+
+# The matrix-free backend path closes that gap for its own slot: the sample
+# `s(τ) = h00·u_k + h10·Δt·du_k + h01·u_{k+1} + h11·Δt·du_{k+1}` is bilinear in
+# `(Δt, du)`, so its only nonzero second derivatives are the CONSTANT cross terms
+# `∂²s/∂Δt∂du_k = h10(τ)` and `∂²s/∂Δt∂du_{k+1} = h11(τ)`. The action below supplies
+# exactly those; on a trajectory whose Δt is not a decision column the terms vanish
+# structurally (no Δt column exists to index).
+
+function constraint_stencil_hvp!(
+    Hv::AbstractVector{Float64},
+    c::CubicSplineBoundConstraint,
+    w::AbstractVector{Float64},
+    v::AbstractVector{Float64},
+    x::AbstractVector{Float64},
+)
+    t = c.table
+    length(Hv) == t.n_cols || throw(
+        DimensionMismatch(
+            "Hv has length $(length(Hv)), expected the full decision width $(t.n_cols)",
+        ),
+    )
+    τs = c.τs
+    cols = t.cols
+    col_ptr = t.col_ptr
+    @inbounds for f in eachindex(τs)
+        ω = stencil_functional_weight(t, w, f)
+        o = col_ptr[f] - 1
+        h10, h11 = hermite_basis_functions(τs[f])[2], hermite_basis_functions(τs[f])[4]
+        vt = v[cols[o+5]]                       # the Δt column
+        v_du_k = v[cols[o+3]]
+        v_du_k1 = v[cols[o+4]]
+        # symmetric cross terms: (Δt, du_k) with h10(τ), (Δt, du_{k+1}) with h11(τ)
+        Hv[cols[o+3]] += ω * h10 * vt
+        Hv[cols[o+4]] += ω * h11 * vt
+        Hv[cols[o+5]] += ω * (h10 * v_du_k + h11 * v_du_k1)
+    end
+    return nothing
+end
+
+supports_matrix_free_constraint_hvp(::CubicSplineBoundConstraint) = true

--- a/src/control/constraints_spline/hermite_primitives.jl
+++ b/src/control/constraints_spline/hermite_primitives.jl
@@ -1,0 +1,408 @@
+# ============================================================================= #
+#   Cubic Hermite spline primitives — the ONE definition                        #
+# ============================================================================= #
+#
+# These were duplicated across two constraint files: `spline_bound_constraints.jl`
+# defined the basis functions and the critical-point solvers, and
+# `cubic_spline_bound_constraint.jl` re-derived the same four basis polynomials
+# inline inside `eval_cubic_hermite` / `eval_cubic_hermite_jacobian`. Both now call
+# these — and as of #331 those two adapters are gone entirely, the value gradient having
+# moved here as `hermite_value_gradient`. Everything here is generic in the scalar type
+# (ForwardDiff.Dual included) and allocation-free except the two root finders, which
+# return a small vector.
+#
+# Part of #330 (ADR-0010): a representation change needs one source of truth for
+# the stencil math, and two independently-maintained copies of the Hermite basis
+# is where a wrong coefficient hides.
+
+# ----------------------------------------------------------------------------- #
+# Basis
+# ----------------------------------------------------------------------------- #
+
+"""
+    hermite_basis_functions(τ)
+
+Evaluate cubic Hermite basis functions at normalized time τ ∈ [0,1].
+
+Returns (h00, h10, h01, h11) where:
+- h00(τ): basis for u_k (position at start)
+- h10(τ): basis for du_k * Δt (tangent at start)
+- h01(τ): basis for u_{k+1} (position at end)
+- h11(τ): basis for du_{k+1} * Δt (tangent at end)
+"""
+function hermite_basis_functions(τ::T) where {T}
+    τ² = τ * τ
+    τ³ = τ² * τ
+
+    h00 = 2τ³ - 3τ² + 1
+    h10 = τ³ - 2τ² + τ
+    h01 = -2τ³ + 3τ²
+    h11 = τ³ - τ²
+
+    return (h00, h10, h01, h11)
+end
+
+"""
+    hermite_derivative_basis(τ)
+
+Evaluate derivative of cubic Hermite basis functions: dh/dτ at τ ∈ [0,1].
+"""
+function hermite_derivative_basis(τ::T) where {T}
+    τ² = τ * τ
+
+    dh00 = 6τ² - 6τ
+    dh10 = 3τ² - 4τ + 1
+    dh01 = -6τ² + 6τ
+    dh11 = 3τ² - 2τ
+
+    return (dh00, dh10, dh01, dh11)
+end
+
+"""
+    evaluate_hermite_spline(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+
+Evaluate cubic Hermite spline at normalized time τ ∈ [0,1].
+
+# Arguments
+- `τ`: Normalized time in [0, 1]
+- `u_k`: Control value at knot k
+- `u_kp1`: Control value at knot k+1
+- `du_k`: Control derivative at knot k
+- `du_kp1`: Control derivative at knot k+1
+- `Δt`: Time step size
+"""
+function evaluate_hermite_spline(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+    h00, h10, h01, h11 = hermite_basis_functions(τ)
+    return h00 * u_k + h10 * Δt * du_k + h01 * u_kp1 + h11 * Δt * du_kp1
+end
+
+"""
+    hermite_value_gradient(du_k, du_kp1, Δt, τ)
+
+Gradient of [`evaluate_hermite_spline`](@ref) at a FIXED τ with respect to the segment's
+decision variables, returned as the tuple
+
+    (∂s/∂u_k, ∂s/∂u_{k+1}, ∂s/∂du_k, ∂s/∂du_{k+1}, ∂s/∂Δt)
+    = (h00, h01, Δt·h10, Δt·h11, h10·du_k + h11·du_{k+1})
+
+The tuple order is the column order the interior-point bound constraint declares to its
+stencil table, so a coefficient refresh can splat it straight into `coeffs`. Returned as
+a tuple, not a vector: `cubic_spline_bound_constraint.jl` previously allocated a
+five-element heap vector per sample point per Jacobian (#331 / ADR-0010).
+
+`s` is linear in `u`/`du`, so this gradient depends on `u` not at all and on `du` only
+through the `Δt` partial.
+
+Generic in the scalar type (ForwardDiff.Dual included); allocation-free.
+"""
+@inline function hermite_value_gradient(du_k, du_kp1, Δt, τ)
+    h00, h10, h01, h11 = hermite_basis_functions(τ)
+    return (h00, h01, Δt * h10, Δt * h11, h10 * du_k + h11 * du_kp1)
+end
+
+"""
+    evaluate_hermite_derivative(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+
+Evaluate derivative of cubic Hermite spline at normalized time τ ∈ [0,1].
+
+Returns du/dt at parameter τ.
+"""
+function evaluate_hermite_derivative(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+    dh00, dh10, dh01, dh11 = hermite_derivative_basis(τ)
+    # du/dt = (du/dτ) / Δt
+    du_dτ = dh00 * u_k + dh10 * Δt * du_k + dh01 * u_kp1 + dh11 * Δt * du_kp1
+    return du_dτ / Δt
+end
+
+# ----------------------------------------------------------------------------- #
+# Second derivative (acceleration) at the two segment endpoints
+# ----------------------------------------------------------------------------- #
+
+"""
+    hermite_accel_start(u_k, u_kp1, du_k, du_kp1, Δt)
+
+Acceleration `d²u/dt²` of the cubic Hermite segment `k → k+1` at its START (τ=0):
+
+    a_start = (6/Δt²)(u_{k+1} - u_k) - (2/Δt)(2 du_k + du_{k+1})
+
+Generic in the scalar type; allocation-free.
+"""
+@inline function hermite_accel_start(u_k, u_kp1, du_k, du_kp1, Δt)
+    # The association `6 * (inv²) * Δu` is deliberate, not incidental: it reproduces
+    # the pre-port expression BIT-FOR-BIT, which is what lets the residual-parity
+    # witness assert `==` rather than a tolerance. `(6 * inv) * inv * Δu` differs in
+    # the last digit.
+    inv_Δt = inv(Δt)
+    inv_Δt² = inv_Δt * inv_Δt
+    return 6 * inv_Δt² * (u_kp1 - u_k) - 2 * inv_Δt * (2 * du_k + du_kp1)
+end
+
+"""
+    hermite_accel_end(u_k, u_kp1, du_k, du_kp1, Δt)
+
+Acceleration `d²u/dt²` of the cubic Hermite segment `k → k+1` at its END (τ=1):
+
+    a_end = -(6/Δt²)(u_{k+1} - u_k) + (2/Δt)(du_k + 2 du_{k+1})
+
+Generic in the scalar type; allocation-free.
+"""
+@inline function hermite_accel_end(u_k, u_kp1, du_k, du_kp1, Δt)
+    # See `hermite_accel_start` on the association.
+    inv_Δt = inv(Δt)
+    inv_Δt² = inv_Δt * inv_Δt
+    return -6 * inv_Δt² * (u_kp1 - u_k) + 2 * inv_Δt * (du_k + 2 * du_kp1)
+end
+
+# ----------------------------------------------------------------------------- #
+# Acceleration gradients as tuples (#333)
+# ----------------------------------------------------------------------------- #
+#
+# WHY THESE EXIST AND WHY THEY ARE NOT A REFACTOR. `hermite_value_gradient` above already
+# returns the cubic-bound constraint's stencil row as a tuple, so #333's device coefficient
+# refresh can BROADCAST the very function the host refresh calls — one source of truth, no
+# divergence possible. The acceleration constraint had no such function: its eighteen
+# partials live inline inside `_hsa_refresh_coefficients!`. A device kernel that re-derived
+# them would be the second copy ADR-0010 warns about ("divergence here is the main
+# long-term risk").
+#
+# These three functions are that missing tuple form, ADDED rather than refactored in:
+# `_hsa_refresh_coefficients!` is the host reference and stays byte-for-byte as #330 left
+# it (#333 AC6). The expressions here reproduce it EXACTLY — same inverse powers, same
+# association, same operand order — and a testitem asserts that bit-for-bit over randomized
+# inputs for all three kinds, so the duplication is pinned rather than trusted.
+#
+# Generic in the scalar type, allocation-free, and GPU-safe (tuple return, no branches).
+
+"""
+    hermite_accel_start_gradient(u_k, u_kp1, du_k, du_kp1, Δt) -> NTuple{5}
+
+Gradient of [`hermite_accel_start`](@ref) with respect to
+`(u_k, u_{k+1}, du_k, du_{k+1}, Δt)` — the column order the acceleration constraint
+declares to its stencil table for an `HSA_A_START` functional.
+"""
+@inline function hermite_accel_start_gradient(u_k, u_kp1, du_k, du_kp1, Δt)
+    i = 1.0 / Δt
+    i2 = i * i
+    i3 = i2 * i
+    return (
+        -6 * i2,
+        6 * i2,
+        -4 * i,
+        -2 * i,
+        -12 * i3 * (u_kp1 - u_k) + 2 * i2 * (2 * du_k + du_kp1),
+    )
+end
+
+"""
+    hermite_accel_end_gradient(u_k, u_kp1, du_k, du_kp1, Δt) -> NTuple{5}
+
+Gradient of [`hermite_accel_end`](@ref) with respect to
+`(u_k, u_{k+1}, du_k, du_{k+1}, Δt)` — the `HSA_A_END` column order.
+"""
+@inline function hermite_accel_end_gradient(u_k, u_kp1, du_k, du_kp1, Δt)
+    i = 1.0 / Δt
+    i2 = i * i
+    i3 = i2 * i
+    return (
+        6 * i2,
+        -6 * i2,
+        2 * i,
+        4 * i,
+        12 * i3 * (u_kp1 - u_k) - 2 * i2 * (du_k + 2 * du_kp1),
+    )
+end
+
+"""
+    hermite_accel_jump_gradient(u_km1, u_k, u_kp1, du_km1, du_k, du_kp1, Δt_km1, Δt_k)
+
+Gradient of the acceleration JUMP
+`hermite_accel_end(u_{k-1}, u_k, du_{k-1}, du_k, Δt_{k-1}) −
+hermite_accel_start(u_k, u_{k+1}, du_k, du_{k+1}, Δt_k)`
+with respect to `(u_{k-1}, u_k, u_{k+1}, du_{k-1}, du_k, du_{k+1}, Δt_{k-1}, Δt_k)` — the
+`HSA_JUMP` column order. Returned as an `NTuple{8}`.
+"""
+@inline function hermite_accel_jump_gradient(
+    u_km1,
+    u_k,
+    u_kp1,
+    du_km1,
+    du_k,
+    du_kp1,
+    Δt_km1,
+    Δt_k,
+)
+    i_km1 = 1.0 / Δt_km1
+    i_k = 1.0 / Δt_k
+    i_km1_2 = i_km1 * i_km1
+    i_km1_3 = i_km1_2 * i_km1
+    i_k_2 = i_k * i_k
+    i_k_3 = i_k_2 * i_k
+    return (
+        6 * i_km1_2,
+        -6 * i_km1_2 + 6 * i_k_2,
+        -6 * i_k_2,
+        2 * i_km1,
+        4 * i_km1 + 4 * i_k,
+        2 * i_k,
+        12 * i_km1_3 * (u_k - u_km1) - 2 * i_km1_2 * (du_km1 + 2 * du_k),
+        12 * i_k_3 * (u_kp1 - u_k) - 2 * i_k_2 * (2 * du_k + du_kp1),
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Critical points
+# ----------------------------------------------------------------------------- #
+
+"""
+    find_cubic_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+
+Find critical points of cubic Hermite spline in [0, 1] where du/dτ = 0.
+
+Returns a vector of τ values in [0, 1] where the spline has extrema.
+
+# Algorithm
+The derivative du/dτ is a quadratic: aτ² + bτ + c = 0
+Solve using quadratic formula and keep roots in (0, 1).
+
+# Note
+Generic implementation compatible with ForwardDiff.Dual numbers.
+"""
+function find_cubic_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+    # Coefficients of du/dτ = aτ² + bτ + c, from `hermite_derivative_basis`:
+    #   du/dτ = dh00·u_k + dh10·Δt·du_k + dh01·u_kp1 + dh11·Δt·du_kp1
+
+    # Collecting terms in τ²:
+    a = 6*u_k + 3*Δt*du_k - 6*u_kp1 + 3*Δt*du_kp1
+
+    # Collecting terms in τ:
+    b = -6*u_k - 4*Δt*du_k + 6*u_kp1 - 2*Δt*du_kp1
+
+    # Constant term:
+    c = Δt * du_k
+
+    # Use generic type for array (compatible with Dual numbers)
+    T = promote_type(typeof(u_k), typeof(u_kp1), typeof(du_k), typeof(du_kp1))
+    critical_points = T[]
+
+    if abs(a) < 1e-12
+        # Linear case: bτ + c = 0
+        if abs(b) > 1e-12
+            τ = -c / b
+            if 0 < τ < 1
+                push!(critical_points, τ)
+            end
+        end
+    else
+        # Quadratic case
+        discriminant = b^2 - 4*a*c
+
+        if discriminant >= 0
+            sqrt_disc = sqrt(discriminant)
+            τ1 = (-b + sqrt_disc) / (2*a)
+            τ2 = (-b - sqrt_disc) / (2*a)
+
+            # Only keep roots in (0, 1) - exclude endpoints since we already check them
+            if 0 < τ1 < 1
+                push!(critical_points, τ1)
+            end
+            if 0 < τ2 < 1
+                push!(critical_points, τ2)
+            end
+        end
+    end
+
+    return critical_points
+end
+
+"""
+    find_hermite_extrema(u_k, u_kp1, du_k, du_kp1, Δt)
+
+Find all extrema (critical points + endpoints) and return their values.
+
+Returns a vector of u values at all critical points and endpoints.
+"""
+function find_hermite_extrema(u_k, u_kp1, du_k, du_kp1, Δt)
+    extrema_values = Float64[u_k, u_kp1]  # Always check endpoints
+
+    τ_crits = find_cubic_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+
+    for τ in τ_crits
+        u_τ = evaluate_hermite_spline(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+        push!(extrema_values, u_τ)
+    end
+
+    return extrema_values
+end
+
+"""
+    find_slope_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+
+Find critical points of the derivative (where d²u/dt² = 0) in [0, 1].
+
+Returns a vector of τ values where the slope has local extrema.
+
+# Algorithm
+The second derivative d²u/dτ² is linear: 2aτ + b = 0
+where a and b are the quadratic coefficients from du/dτ.
+"""
+function find_slope_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+    # From find_cubic_critical_points, we have du/dτ = aτ² + bτ + c
+    # So d²u/dτ² = 2aτ + b
+
+    a = 6*u_k + 3*Δt*du_k - 6*u_kp1 + 3*Δt*du_kp1
+    b = -6*u_k - 4*Δt*du_k + 6*u_kp1 - 2*Δt*du_kp1
+
+    T = promote_type(typeof(u_k), typeof(u_kp1), typeof(du_k), typeof(du_kp1))
+    critical_points = T[]
+
+    if abs(a) > 1e-12
+        # Linear d²u/dτ² = 0: 2aτ + b = 0
+        τ = -b / (2*a)
+        if 0 < τ < 1
+            push!(critical_points, τ)
+        end
+    end
+    # If a ≈ 0, derivative is constant (no extrema in interior)
+
+    return critical_points
+end
+
+@testitem "Hermite primitives: one definition, endpoints, and the two accelerations" begin
+
+    hermite_basis_functions,
+    hermite_derivative_basis,
+    evaluate_hermite_spline,
+    evaluate_hermite_derivative,
+    hermite_accel_start,
+    hermite_accel_end
+    using ForwardDiff
+    using Random
+
+    Random.seed!(0x330ABC1)
+
+    # Basis partition-of-unity / endpoint interpolation
+    h0 = hermite_basis_functions(0.0)
+    @test h0 == (1.0, 0.0, 0.0, 0.0)
+    h1 = hermite_basis_functions(1.0)
+    @test h1 == (0.0, 0.0, 1.0, 0.0)
+
+    u_k, u_kp1, du_k, du_kp1, Δt = randn(), randn(), randn(), randn(), 0.17
+    @test evaluate_hermite_spline(0.0, u_k, u_kp1, du_k, du_kp1, Δt) ≈ u_k
+    @test evaluate_hermite_spline(1.0, u_k, u_kp1, du_k, du_kp1, Δt) ≈ u_kp1
+    @test evaluate_hermite_derivative(0.0, u_k, u_kp1, du_k, du_kp1, Δt) ≈ du_k
+    @test evaluate_hermite_derivative(1.0, u_k, u_kp1, du_k, du_kp1, Δt) ≈ du_kp1
+
+    # The accelerations ARE the second derivative of the spline at τ = 0, 1 —
+    # this is the identity the smooth-acceleration constraint's stencil rests on.
+    s = τ -> evaluate_hermite_spline(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+    d2 = τ -> ForwardDiff.derivative(t -> ForwardDiff.derivative(s, t), τ) / Δt^2
+    @test hermite_accel_start(u_k, u_kp1, du_k, du_kp1, Δt) ≈ d2(0.0)
+    @test hermite_accel_end(u_k, u_kp1, du_k, du_kp1, Δt) ≈ d2(1.0)
+
+    # dh basis is the τ-derivative of the h basis
+    for τ in (0.0, 0.25, 0.5, 1.0)
+        dh = hermite_derivative_basis(τ)
+        dh_ad = ForwardDiff.derivative(t -> collect(hermite_basis_functions(t)), τ)
+        @test all(isapprox.(collect(dh), dh_ad; atol = 1e-12))
+    end
+end

--- a/src/control/constraints_spline/hermite_primitives.jl
+++ b/src/control/constraints_spline/hermite_primitives.jl
@@ -369,12 +369,13 @@ end
 
 @testitem "Hermite primitives: one definition, endpoints, and the two accelerations" begin
 
-    hermite_basis_functions,
-    hermite_derivative_basis,
-    evaluate_hermite_spline,
-    evaluate_hermite_derivative,
-    hermite_accel_start,
-    hermite_accel_end
+    using Piccolo:
+        evaluate_hermite_derivative,
+        evaluate_hermite_spline,
+        hermite_accel_end,
+        hermite_accel_start,
+        hermite_basis_functions,
+        hermite_derivative_basis
     using ForwardDiff
     using Random
 

--- a/src/control/constraints_spline/hermite_smooth_acceleration_constraint.jl
+++ b/src/control/constraints_spline/hermite_smooth_acceleration_constraint.jl
@@ -1080,12 +1080,10 @@ end
 @testitem "#330 AC1/AC2: ported residual matches the reference; Jacobian matches forward-mode AD" begin
     using NamedTrajectories
 
-    HermiteSmoothAccelerationConstraint,
-    evaluate!,
-    jacobian!,
-    jacobian_structure,
-    eval_jacobian,
-    _reference_evaluate!
+    using Piccolo: HermiteSmoothAccelerationConstraint, eval_jacobian
+    using DirectTrajOpt.CommonInterface: evaluate!, jacobian_structure
+    using DirectTrajOpt.Constraints: jacobian!
+    using Piccolo.Control.QuantumConstraints.SplineConstraints: _reference_evaluate!
     using ForwardDiff
     using SparseArrays
     using LinearAlgebra
@@ -1243,7 +1241,9 @@ end
 @testitem "#330 AC3: residual and Jacobian allocation are invariant to knot count" begin
     using NamedTrajectories
 
-    HermiteSmoothAccelerationConstraint, evaluate!, jacobian!, eval_jacobian
+    using Piccolo: HermiteSmoothAccelerationConstraint, eval_jacobian
+    using DirectTrajOpt.CommonInterface: evaluate!
+    using DirectTrajOpt.Constraints: jacobian!
     using Random
 
     # KNOT-FLATNESS, not zero allocation. The interface hands the constraint a
@@ -1520,10 +1520,11 @@ supports_matrix_free_constraint_hvp(::HermiteSmoothAccelerationConstraint) = tru
 @testitem "#458 HSA exact inequality HVP: FD parity of the weighted residual Hessian" begin
     using NamedTrajectories
 
-    HermiteSmoothAccelerationConstraint,
-    constraint_stencil_hvp!,
-    supports_matrix_free_constraint_hvp,
-    evaluate!
+    using Piccolo:
+        HermiteSmoothAccelerationConstraint,
+        constraint_stencil_hvp!,
+        supports_matrix_free_constraint_hvp
+    using DirectTrajOpt.CommonInterface: evaluate!
     using ForwardDiff
     using LinearAlgebra
     using Random
@@ -1629,7 +1630,7 @@ end
 @testitem "#458 HSA inequality HVP: allocation is invariant to knot count" begin
     using NamedTrajectories
 
-    HermiteSmoothAccelerationConstraint, constraint_stencil_hvp!
+    using Piccolo: HermiteSmoothAccelerationConstraint, constraint_stencil_hvp!
     using Random
 
     function measure(N)

--- a/src/control/constraints_spline/hermite_smooth_acceleration_constraint.jl
+++ b/src/control/constraints_spline/hermite_smooth_acceleration_constraint.jl
@@ -1,0 +1,1667 @@
+"""
+    HermiteSmoothAccelerationConstraint <: AbstractNonlinearConstraint
+
+Unified constraint that enforces both acceleration bounds AND C² continuity for Hermite cubic splines.
+
+This constraint combines:
+1. **Acceleration bounds**: |a| ≤ a_max at all knot points
+2. **C² continuity**: acceleration continuity at interior knots (no jumps)
+
+By enforcing continuity, we only need to bound acceleration once per interior knot (instead of
+twice for endpoints of adjacent segments), making this more efficient than separate constraints.
+
+**Constraint structure:**
+
+For N knots and n_drives control drives (all segments constrained):
+- At knot 1 (start): bound a_start(segment 1) with 2×n_drives inequalities (±a_max)
+- At knots 2 to N-1 (interior):
+  - Continuity (double-sided): a_end(k-1) = a_start(k) → 2×(N-2)×n_drives inequalities
+  - Bounds: |a| ≤ a_max where a is the common acceleration → 2×(N-2)×n_drives inequalities
+- At knot N (end): bound a_end(segment N-1) with 2×n_drives inequalities (±a_max)
+
+Total: `4 × n_segments × n_drives` inequalities, where `n_segments = length(segments)`.
+
+**Acceleration formulas** (`hermite_accel_start` / `hermite_accel_end`):
+
+At start of segment k (s=0, knot k):
+    a_start(k) = (6/Δt_k²)(u_{k+1} - u_k) - (2/Δt_k)(2du_k + du_{k+1})
+
+At end of segment k (s=1, knot k+1):
+    a_end(k) = -(6/Δt_k²)(u_{k+1} - u_k) + (2/Δt_k)(du_k + 2du_{k+1})
+
+# Constructor
+```julia
+HermiteSmoothAccelerationConstraint(
+    traj::NamedTrajectory;
+    a_max::Real,
+    control_name::Symbol=:u,
+    segments::AbstractVector{Int}=1:traj.N-1,
+)
+```
+
+# Arguments
+- `traj`: NamedTrajectory with cubic spline controls (requires :u, :du, and :Δt components)
+- `a_max`: Maximum allowed acceleration magnitude
+- `control_name`: Name of the control variable (default: :u)
+- `segments`: Which spline segments to constrain (default: all). Continuity is enforced
+  at the interior knots of each maximal contiguous run of `segments`; each run's leading
+  `a_start` and every segment's `a_end` are bounded.
+
+# Example
+```julia
+# Smooth acceleration with bounds ±10 MHz/μs²
+constraint = HermiteSmoothAccelerationConstraint(
+    traj;
+    a_max=10.0
+)
+```
+
+# Representation
+
+The residual and Jacobian are served from a `ConstraintStencilTable` (ADR-0010): one
+table row per unique scalar acceleration functional, the constant columns declared
+once at construction, and only the coefficients refreshed per iterate. The kernels
+read the trajectory's flat data vector at those precomputed columns through a function
+barrier — never the named-component accessor, which is inferred as `Any` and boxes
+~38.6 B per scalar read.
+
+# Allocation
+
+**Not** zero-allocation, and zero allocation is not the target. The interface hands the
+constraint a `NamedTrajectory` whose `datavec` is an abstractly-typed field, so one
+dynamic access costs a constant floor of ~80 B; the backend's own per-callback
+trajectory wrapper costs ~3.3 kB, roughly forty times a whole kernel here. What IS
+guaranteed, and gated, is **knot-flatness**: per-call allocation for both `evaluate!`
+and the Jacobian is independent of the knot count. See ADR-0009 decision 3 and
+ADR-0010 decision 6.
+
+# Notes
+- Replaces both HermiteAccelerationConstraint and HermiteAccelerationContinuityConstraint
+- More efficient: fewer total constraints than using both separately
+- Results in C² continuous splines with bounded acceleration
+"""
+struct HermiteSmoothAccelerationConstraint <: AbstractNonlinearConstraint
+    control_name::Symbol
+    derivative_name::Symbol
+    timestep_name::Symbol
+    n_drives::Int
+    N_segments::Int
+    segments::Vector{Int}
+    a_max::Float64
+    equality::Bool  # Always false (pure inequality formulation)
+    g_dim::Int  # Total constraints: 4 * length(segments) * n_drives
+    dim::Int  # Same as g_dim for this constraint
+
+    # Functional-indexed stencil table: the declared structure (constant columns,
+    # signed row map, per-row constant, stencil width) plus the per-iterate
+    # coefficients. Application is generic over it.
+    table::ConstraintStencilTable
+
+    # Per-functional kind tag — which closed-form scalar this functional is. The
+    # constraint's own math; the table neither reads nor interprets it.
+    kinds::Vector{Int8}
+
+    # Jacobian sparsity structure (derived from the table, cached for the interface)
+    jac_structure::Vector{Tuple{Int,Int}}
+
+    # Hessian sparsity structure
+    hess_structure::Vector{Tuple{Int,Int}}
+end
+
+# ----------------------------------------------------------------------------- #
+# Functional kinds
+# ----------------------------------------------------------------------------- #
+#
+# Column layouts, fixed by the declaration below and read by the barrier kernels:
+#
+#   HSA_A_START (5): [u_k, u_{k+1}, du_k, du_{k+1}, Δt_k]
+#   HSA_A_END   (5): [u_k, u_{k+1}, du_k, du_{k+1}, Δt_k]
+#   HSA_JUMP    (8): [u_{k-1}, u_k, u_{k+1}, du_{k-1}, du_k, du_{k+1}, Δt_{k-1}, Δt_k]
+
+const HSA_A_START = Int8(1)
+const HSA_A_END = Int8(2)
+const HSA_JUMP = Int8(3)
+
+# Stencil width: a bound/continuity row reads at most knots k-1, k, k+1 around its
+# anchor, i.e. one knot either side. DECLARED, never acted on here — the sharded
+# driver takes `max` over dynamics and every routed constraint and exchanges once.
+const HSA_STENCIL_WIDTH = 1
+
+function HermiteSmoothAccelerationConstraint(
+    traj::NamedTrajectory;
+    a_max::Real,
+    control_name::Symbol = :u,
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+)
+    # Validate trajectory components
+    @assert haskey(traj.components, control_name) "Trajectory missing control: $control_name"
+
+    derivative_name = Symbol("d" * string(control_name))
+    @assert haskey(traj.components, derivative_name) "Trajectory missing derivative: $derivative_name"
+
+    timestep_name = traj.timestep
+    @assert !isnothing(timestep_name) "Trajectory missing timestep"
+
+    n_drives = traj.dims[control_name]
+    N_timesteps = traj.N
+
+    segs = sort(unique(collect(Int, segments)))
+    @assert !isempty(segs) "segments is empty — nothing to constrain"
+    @assert first(segs) >= 1 && last(segs) <= N_timesteps - 1 "segments must lie in 1:$(N_timesteps-1)"
+    N_segments = length(segs)
+    in_seg = falses(N_timesteps - 1)
+    for k in segs
+        in_seg[k] = true
+    end
+
+    # All constraints as inequalities, `±` row pairs sharing one functional:
+    #   continuity at every interior knot of a segment run, plus a bound on each
+    #   run's leading a_start and on every segment's a_end.
+    g_dim = 4 * N_segments * n_drives
+
+    # ── Column tables. THE FULL DECISION-VECTOR WIDTH, INCLUDING GLOBALS, and it is
+    # carried as data on the table rather than recomputed at each use site: sizing the
+    # Jacobian without the global columns is what made the backend's row-stacking throw
+    # outright on any trajectory carrying free phases.
+    n_cols = traj.dim * traj.N + traj.global_dim
+    u_comps = traj.components[control_name]
+    du_comps = traj.components[derivative_name]
+    dt_comps = traj.components[timestep_name]
+    u_col = (k, d) -> slice(k, u_comps, traj.dim)[d]
+    du_col = (k, d) -> slice(k, du_comps, traj.dim)[d]
+    dt_col = k -> slice(k, dt_comps, traj.dim)[1]
+
+    functional_cols = Vector{Vector{Int}}()
+    kinds = Int8[]
+    row_map = Int[]
+    row_offset = Float64[]
+
+    # A functional emitted with its `±` row pair — CONTIGUOUS by construction, which is
+    # the invariant `ConstraintStencilTable` enforces.
+    push_functional! = (kind, cols, offset) -> begin
+        push!(functional_cols, cols)
+        push!(kinds, kind)
+        f = length(functional_cols)
+        push!(row_map, f)
+        push!(row_offset, offset)
+        push!(row_map, -f)
+        push!(row_offset, offset)
+        return f
+    end
+
+    # ── Continuity: knot k is interior to a run iff segments k-1 and k are both in.
+    # Row order matches the pre-port implementation exactly (all-segments default:
+    # k = 2:N-1).
+    for k in segs
+        (k >= 2 && in_seg[k-1]) || continue
+        for d = 1:n_drives
+            push_functional!(
+                HSA_JUMP,
+                [
+                    u_col(k - 1, d),
+                    u_col(k, d),
+                    u_col(k + 1, d),
+                    du_col(k - 1, d),
+                    du_col(k, d),
+                    du_col(k + 1, d),
+                    dt_col(k - 1),
+                    dt_col(k),
+                ],
+                0.0,
+            )
+        end
+    end
+
+    # ── Bounds: each run's leading a_start (default: knot 1) …
+    for k in segs
+        (k == 1 || !in_seg[k-1]) || continue
+        for d = 1:n_drives
+            push_functional!(
+                HSA_A_START,
+                [u_col(k, d), u_col(k + 1, d), du_col(k, d), du_col(k + 1, d), dt_col(k)],
+                -Float64(a_max),
+            )
+        end
+    end
+
+    # … then a_end of every non-final segment of a run (default: interior knots 2:N-1,
+    # whose common acceleration is a_end(k-1)) …
+    for k in segs
+        (k + 1 <= N_timesteps - 1 && in_seg[k+1]) || continue
+        for d = 1:n_drives
+            push_functional!(
+                HSA_A_END,
+                [u_col(k, d), u_col(k + 1, d), du_col(k, d), du_col(k + 1, d), dt_col(k)],
+                -Float64(a_max),
+            )
+        end
+    end
+
+    # … then a_end of each run's final segment (default: knot N).
+    for k in segs
+        (k + 1 > N_timesteps - 1 || !in_seg[k+1]) || continue
+        for d = 1:n_drives
+            push_functional!(
+                HSA_A_END,
+                [u_col(k, d), u_col(k + 1, d), du_col(k, d), du_col(k + 1, d), dt_col(k)],
+                -Float64(a_max),
+            )
+        end
+    end
+
+    @assert length(row_map) == g_dim "internal: emitted $(length(row_map)) rows, expected $g_dim"
+
+    table = ConstraintStencilTable(
+        functional_cols,
+        row_map,
+        row_offset,
+        n_cols;
+        stencil_width = HSA_STENCIL_WIDTH,
+    )
+
+    # Build Hessian sparsity structure
+    # Include second derivatives involving Δt for:
+    # 1. Within-segment terms (for bound constraints)
+    # 2. Cross-segment terms (for continuity constraints)
+    hess_structure = Tuple{Int,Int}[]
+
+    # Within-segment terms, for each constrained segment
+    for k in segs
+        for drive_idx = 1:n_drives
+            var_indices = [
+                u_col(k, drive_idx),
+                u_col(k + 1, drive_idx),
+                du_col(k, drive_idx),
+                du_col(k + 1, drive_idx),
+                dt_col(k),
+            ]
+
+            for i = 1:length(var_indices)
+                for j = 1:i
+                    idx_i = var_indices[i]
+                    idx_j = var_indices[j]
+                    push!(hess_structure, (max(idx_i, idx_j), min(idx_i, idx_j)))
+                end
+            end
+        end
+    end
+
+    # Cross-segment Hessian entries for continuity constraints:
+    # Δt_{k-1} with variables from segment k, and Δt_k with variables from segment k-1
+    for k in segs
+        (k >= 2 && in_seg[k-1]) || continue
+        dt_km1 = dt_col(k - 1)
+        dt_k = dt_col(k)
+
+        for drive_idx = 1:n_drives
+            seg_k_vars = [
+                u_col(k, drive_idx),
+                u_col(k + 1, drive_idx),
+                du_col(k, drive_idx),
+                du_col(k + 1, drive_idx),
+                dt_k,
+            ]
+            for var in seg_k_vars
+                push!(hess_structure, (max(dt_km1, var), min(dt_km1, var)))
+            end
+
+            seg_km1_vars = [
+                u_col(k - 1, drive_idx),
+                u_col(k, drive_idx),
+                du_col(k - 1, drive_idx),
+                du_col(k, drive_idx),
+                dt_km1,
+            ]
+            for var in seg_km1_vars
+                push!(hess_structure, (max(dt_k, var), min(dt_k, var)))
+            end
+        end
+    end
+
+    # Remove duplicates and sort
+    hess_structure = unique(hess_structure)
+    sort!(hess_structure)
+
+    return HermiteSmoothAccelerationConstraint(
+        control_name,
+        derivative_name,
+        timestep_name,
+        n_drives,
+        N_segments,
+        segs,
+        Float64(a_max),
+        false,  # equality field (pure inequality formulation)
+        g_dim,
+        g_dim,  # dim = g_dim
+        table,
+        kinds,
+        stencil_structure(table),
+        hess_structure,
+    )
+end
+
+# CommonInterface methods
+import DirectTrajOpt.CommonInterface: jacobian_structure, hessian_structure
+import DirectTrajOpt.CommonInterface: evaluate!, jacobian!, hessian_of_lagrangian
+
+jacobian_structure(c::HermiteSmoothAccelerationConstraint) = c.jac_structure
+hessian_structure(c::HermiteSmoothAccelerationConstraint) = c.hess_structure
+
+"""
+    stencil_width(constraint::HermiteSmoothAccelerationConstraint) -> Int
+
+The declared stencil width: the maximum number of knots either side of its anchor that
+one constraint row reads. 1 here — a continuity row couples `k-1, k, k+1`.
+
+Declared, never acted on: halo exchange belongs to the sharded driver, which takes
+`max` over dynamics and every routed constraint and exchanges once per callback.
+"""
+stencil_width(c::HermiteSmoothAccelerationConstraint) = c.table.stencil_width
+
+# ----------------------------------------------------------------------------- #
+# Barrier kernels
+# ----------------------------------------------------------------------------- #
+#
+# `Z` arrives as `traj.datavec`, an abstractly-typed FIELD — reading scalars through it
+# at the call site (or through `traj[name]`, which is inferred as `Any`) boxes every
+# intermediate and was ~98% of the pre-port residual allocation. These functions are
+# the FUNCTION BARRIER: one dynamic dispatch at entry, then a fully concrete body.
+# Passing component *views* through a barrier is measurably not sufficient — it leaves
+# a constant kilobyte-scale floor.
+
+"""
+    _hsa_functional_value(kind, Z, cols, o)
+
+The closed-form scalar for one functional: `kind` selects the formula, `cols[o+1…]`
+are its precomputed decision-vector columns. Generic in `eltype(Z)`.
+"""
+@inline function _hsa_functional_value(
+    kind::Int8,
+    Z::AbstractVector,
+    cols::Vector{Int},
+    o::Int,
+)
+    @inbounds if kind == HSA_JUMP
+        u_km1 = Z[cols[o+1]]
+        u_k = Z[cols[o+2]]
+        u_kp1 = Z[cols[o+3]]
+        du_km1 = Z[cols[o+4]]
+        du_k = Z[cols[o+5]]
+        du_kp1 = Z[cols[o+6]]
+        Δt_km1 = Z[cols[o+7]]
+        Δt_k = Z[cols[o+8]]
+        return hermite_accel_end(u_km1, u_k, du_km1, du_k, Δt_km1) -
+               hermite_accel_start(u_k, u_kp1, du_k, du_kp1, Δt_k)
+    else
+        u_a = Z[cols[o+1]]
+        u_b = Z[cols[o+2]]
+        du_a = Z[cols[o+3]]
+        du_b = Z[cols[o+4]]
+        Δt = Z[cols[o+5]]
+        return kind == HSA_A_START ? hermite_accel_start(u_a, u_b, du_a, du_b, Δt) :
+               hermite_accel_end(u_a, u_b, du_a, du_b, Δt)
+    end
+end
+
+"""
+    _hsa_residual!(g, Z, kinds, table)
+
+Residual barrier: form each functional and scatter it straight into its (contiguous)
+`±` row pair. No per-functional buffer, so this is generic in `eltype(g)` /
+`eltype(Z)` — forward-mode AD of this very function is the Jacobian oracle.
+"""
+function _hsa_residual!(
+    g::AbstractVector,
+    Z::AbstractVector,
+    kinds::Vector{Int8},
+    table::ConstraintStencilTable,
+)
+    cols = table.cols
+    col_ptr = table.col_ptr
+    @inbounds for f in eachindex(kinds)
+        val = _hsa_functional_value(kinds[f], Z, cols, col_ptr[f] - 1)
+        stencil_scatter_functional!(g, table, f, val)
+    end
+    return nothing
+end
+
+"""
+    _hsa_refresh_coefficients!(Z, kinds, table)
+
+Per-iterate coefficient refresh: overwrite `table.coeffs` with ∂functional/∂column, in
+the declared column order. The `±` row signs are the table's business, not this
+kernel's.
+"""
+function _hsa_refresh_coefficients!(
+    Z::AbstractVector,
+    kinds::Vector{Int8},
+    table::ConstraintStencilTable,
+)
+    cols = table.cols
+    col_ptr = table.col_ptr
+    coeffs = table.coeffs
+    @inbounds for f in eachindex(kinds)
+        o = col_ptr[f] - 1
+        kind = kinds[f]
+        if kind == HSA_JUMP
+            u_km1 = Z[cols[o+1]]
+            u_k = Z[cols[o+2]]
+            u_kp1 = Z[cols[o+3]]
+            du_km1 = Z[cols[o+4]]
+            du_k = Z[cols[o+5]]
+            du_kp1 = Z[cols[o+6]]
+            i_km1 = 1.0 / Z[cols[o+7]]
+            i_k = 1.0 / Z[cols[o+8]]
+            i_km1_2 = i_km1 * i_km1
+            i_km1_3 = i_km1_2 * i_km1
+            i_k_2 = i_k * i_k
+            i_k_3 = i_k_2 * i_k
+            # ∂/∂(u_{k-1}, u_k, u_{k+1}, du_{k-1}, du_k, du_{k+1}, Δt_{k-1}, Δt_k)
+            coeffs[o+1] = 6 * i_km1_2
+            coeffs[o+2] = -6 * i_km1_2 + 6 * i_k_2
+            coeffs[o+3] = -6 * i_k_2
+            coeffs[o+4] = 2 * i_km1
+            coeffs[o+5] = 4 * i_km1 + 4 * i_k
+            coeffs[o+6] = 2 * i_k
+            coeffs[o+7] = 12 * i_km1_3 * (u_k - u_km1) - 2 * i_km1_2 * (du_km1 + 2 * du_k)
+            coeffs[o+8] = 12 * i_k_3 * (u_kp1 - u_k) - 2 * i_k_2 * (2 * du_k + du_kp1)
+        else
+            u_a = Z[cols[o+1]]
+            u_b = Z[cols[o+2]]
+            du_a = Z[cols[o+3]]
+            du_b = Z[cols[o+4]]
+            i = 1.0 / Z[cols[o+5]]
+            i2 = i * i
+            i3 = i2 * i
+            if kind == HSA_A_START
+                # a_start = 6/Δt²(u_b - u_a) - 2/Δt(2 du_a + du_b)
+                coeffs[o+1] = -6 * i2
+                coeffs[o+2] = 6 * i2
+                coeffs[o+3] = -4 * i
+                coeffs[o+4] = -2 * i
+                coeffs[o+5] = -12 * i3 * (u_b - u_a) + 2 * i2 * (2 * du_a + du_b)
+            else
+                # a_end = -6/Δt²(u_b - u_a) + 2/Δt(du_a + 2 du_b)
+                coeffs[o+1] = 6 * i2
+                coeffs[o+2] = -6 * i2
+                coeffs[o+3] = 2 * i
+                coeffs[o+4] = 4 * i
+                coeffs[o+5] = 12 * i3 * (u_b - u_a) - 2 * i2 * (du_a + 2 * du_b)
+            end
+        end
+    end
+    stencil_touch!(table)
+    return nothing
+end
+
+# ── The constraint-type gradient trait (#332) ─────────────────────────────────── #
+#
+# Two methods, and `supports_matrix_free_constraint_gradient` follows from them: this
+# constraint declares a bounded stencil width (a continuity row couples `k-1, k, k+1`,
+# i.e. one knot either side), so the backend's inequality path serves its rows from
+# `stencil_jvp!` / `stencil_vjp!` and gives it no block in the assembled matrix.
+# `eval_jacobian` below is untouched and stays the assembled contract for Ipopt/MadNLP.
+
+constraint_stencil_table(c::HermiteSmoothAccelerationConstraint) = c.table
+
+refresh_constraint_coefficients!(
+    c::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+) = _hsa_refresh_coefficients!(traj.datavec, c.kinds, c.table)
+
+"""
+    evaluate!(g, constraint, traj)
+
+Evaluate acceleration constraints as pure inequalities (≤ 0):
+- Continuity (double-sided): a_end(k-1) - a_start(k) ≤ 0 AND a_start(k) - a_end(k-1) ≤ 0
+- Bounds (double-sided): a - a_max ≤ 0 AND -a - a_max ≤ 0
+"""
+function evaluate!(
+    g::AbstractVector,
+    constraint::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+)
+    _hsa_residual!(g, traj.datavec, constraint.kinds, constraint.table)
+    return nothing
+end
+
+"""
+    jacobian!(jac, constraint, traj)
+
+Compute the Jacobian's nonzero values, in `jacobian_structure` order.
+"""
+function jacobian!(
+    jac::AbstractVector,
+    constraint::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+)
+    _hsa_refresh_coefficients!(traj.datavec, constraint.kinds, constraint.table)
+    stencil_fill_values!(jac, constraint.table)
+    return nothing
+end
+
+# The `± a_end(k) - a_max` Hessian block, shared by the two bound emissions in
+# `hessian_of_lagrangian!` below (previously written out twice under `k-1`/`k` aliases).
+function _hsa_add_a_end_hessian!(
+    add_hess!,
+    μ,
+    constraint_idx0,
+    u,
+    du,
+    Δt,
+    k,
+    n_drives,
+    u_col,
+    du_col,
+    dt_col,
+)
+    inv_Δt = 1.0 / Δt[k]
+    inv_Δt_2 = inv_Δt * inv_Δt
+    inv_Δt_3 = inv_Δt_2 * inv_Δt
+    inv_Δt_4 = inv_Δt_3 * inv_Δt
+
+    idx = constraint_idx0
+    for drive_idx = 1:n_drives
+        @inbounds begin
+            u_a = u[drive_idx, k]
+            u_b = u[drive_idx, k+1]
+            du_a = du[drive_idx, k]
+            du_b = du[drive_idx, k+1]
+        end
+
+        u_a_v = u_col(k, drive_idx)
+        u_b_v = u_col(k + 1, drive_idx)
+        du_a_v = du_col(k, drive_idx)
+        du_b_v = du_col(k + 1, drive_idx)
+        dt_v = dt_col(k)
+
+        # g = a_end - a_max
+        @inbounds μ_pos = μ[idx]
+        add_hess!(
+            dt_v,
+            dt_v,
+            μ_pos * (-36 * inv_Δt_4 * (u_b - u_a) + 4 * inv_Δt_3 * (du_a + 2 * du_b)),
+        )
+        add_hess!(u_a_v, dt_v, μ_pos * (-12*inv_Δt_3))
+        add_hess!(u_b_v, dt_v, μ_pos * (12*inv_Δt_3))
+        add_hess!(du_a_v, dt_v, μ_pos * (-2*inv_Δt_2))
+        add_hess!(du_b_v, dt_v, μ_pos * (-4*inv_Δt_2))
+        idx += 1
+
+        # g = -a_end - a_max
+        @inbounds μ_neg = μ[idx]
+        add_hess!(
+            dt_v,
+            dt_v,
+            -μ_neg * (-36 * inv_Δt_4 * (u_b - u_a) + 4 * inv_Δt_3 * (du_a + 2 * du_b)),
+        )
+        add_hess!(u_a_v, dt_v, -μ_neg * (-12*inv_Δt_3))
+        add_hess!(u_b_v, dt_v, -μ_neg * (12*inv_Δt_3))
+        add_hess!(du_a_v, dt_v, -μ_neg * (-2*inv_Δt_2))
+        add_hess!(du_b_v, dt_v, -μ_neg * (-4*inv_Δt_2))
+        idx += 1
+    end
+
+    return nothing
+end
+
+"""
+    hessian_of_lagrangian!(hess, μ, constraint, traj)
+
+Compute Hessian of Lagrangian weighted by multipliers μ.
+
+The acceleration formulas are:
+- a_start = (6/Δt²)(u_{k+1} - u_k) - (2/Δt)(2*du_k + du_{k+1})
+- a_end = -(6/Δt²)(u_{k+1} - u_k) + (2/Δt)(du_k + 2*du_{k+1})
+
+Second derivatives (all involve Δt since a is linear in u, du):
+- ∂²a_start/∂Δt² = 36/Δt⁴ * (u_{k+1} - u_k) - 4/Δt³ * (2*du_k + du_{k+1})
+- ∂²a_start/∂u_k∂Δt = 12/Δt³
+- ∂²a_start/∂u_{k+1}∂Δt = -12/Δt³
+- ∂²a_start/∂du_k∂Δt = 4/Δt²
+- ∂²a_start/∂du_{k+1}∂Δt = 2/Δt²
+
+- ∂²a_end/∂Δt² = -36/Δt⁴ * (u_{k+1} - u_k) + 4/Δt³ * (du_k + 2*du_{k+1})
+- ∂²a_end/∂u_k∂Δt = -12/Δt³
+- ∂²a_end/∂u_{k+1}∂Δt = 12/Δt³
+- ∂²a_end/∂du_k∂Δt = -2/Δt²
+- ∂²a_end/∂du_{k+1}∂Δt = -4/Δt²
+
+Deliberately NOT ported onto the stencil table: the backend does not use a Hessian for
+algebraic constraints (its inequality path passes
+`compute_inequality_constraint_hvp! = nothing`), so this stays on the upstream
+`hess_structure` path for the interior-point solvers that do.
+"""
+@views function hessian_of_lagrangian!(
+    hess::AbstractVector,
+    μ::AbstractVector,
+    constraint::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+)
+    u = traj[constraint.control_name]
+    du = traj[constraint.derivative_name]
+    Δt = traj[constraint.timestep_name]
+
+    n_drives = constraint.n_drives
+    hess_struct = constraint.hess_structure
+    segs = constraint.segments
+    N_timesteps = traj.N
+    in_seg = falses(N_timesteps - 1)
+    for k in segs
+        in_seg[k] = true
+    end
+
+    fill!(hess, 0.0)
+
+    # Build lookup table for O(1) Hessian index access
+    hess_lookup = Dict{Tuple{Int,Int},Int}()
+    for (idx, pair) in enumerate(hess_struct)
+        hess_lookup[pair] = idx
+    end
+
+    # Helper to add to Hessian (lower triangular format: row >= col)
+    add_hess! = (i, j, val) -> begin
+        key = (max(i, j), min(i, j))
+        idx = get(hess_lookup, key, nothing)
+        if !isnothing(idx)
+            @inbounds hess[idx] += val
+        end
+        return nothing
+    end
+
+    u_comps = traj.components[constraint.control_name]
+    du_comps = traj.components[constraint.derivative_name]
+    dt_comps = traj.components[constraint.timestep_name]
+    u_col = (k, d) -> slice(k, u_comps, traj.dim)[d]
+    du_col = (k, d) -> slice(k, du_comps, traj.dim)[d]
+    dt_col = k -> slice(k, dt_comps, traj.dim)[1]
+
+    constraint_idx = 1
+
+    # === Continuity inequalities (double-sided), in the same row order as the
+    # residual: interior knots of each segment run ===
+    for k in segs
+        (k >= 2 && in_seg[k-1]) || continue
+
+        inv_Δt_km1 = 1.0 / Δt[k-1]
+        inv_Δt_k = 1.0 / Δt[k]
+        inv_Δt_km1_2 = inv_Δt_km1 * inv_Δt_km1
+        inv_Δt_km1_3 = inv_Δt_km1_2 * inv_Δt_km1
+        inv_Δt_km1_4 = inv_Δt_km1_3 * inv_Δt_km1
+        inv_Δt_k_2 = inv_Δt_k * inv_Δt_k
+        inv_Δt_k_3 = inv_Δt_k_2 * inv_Δt_k
+        inv_Δt_k_4 = inv_Δt_k_3 * inv_Δt_k
+
+        for drive_idx = 1:n_drives
+            @inbounds begin
+                u_km1_val = u[drive_idx, k-1]
+                u_k_val = u[drive_idx, k]
+                u_kp1_val = u[drive_idx, k+1]
+                du_km1_val = du[drive_idx, k-1]
+                du_k_val = du[drive_idx, k]
+                du_kp1_val = du[drive_idx, k+1]
+            end
+
+            u_km1_v = u_col(k - 1, drive_idx)
+            u_k_v = u_col(k, drive_idx)
+            u_kp1_v = u_col(k + 1, drive_idx)
+            du_km1_v = du_col(k - 1, drive_idx)
+            du_k_v = du_col(k, drive_idx)
+            du_kp1_v = du_col(k + 1, drive_idx)
+            dt_km1_v = dt_col(k - 1)
+            dt_k_v = dt_col(k)
+
+            # Forward inequality: g = a_end(k-1) - a_start(k)
+            @inbounds μ_fwd = μ[constraint_idx]
+
+            # ∂²a_end(k-1)/∂Δt_{k-1}²
+            add_hess!(
+                dt_km1_v,
+                dt_km1_v,
+                μ_fwd * (
+                    -36 * inv_Δt_km1_4 * (u_k_val - u_km1_val) +
+                    4 * inv_Δt_km1_3 * (du_km1_val + 2*du_k_val)
+                ),
+            )
+            # -∂²a_start(k)/∂Δt_k²
+            add_hess!(
+                dt_k_v,
+                dt_k_v,
+                μ_fwd * (-(
+                    36 * inv_Δt_k_4 * (u_kp1_val - u_k_val) -
+                    4 * inv_Δt_k_3 * (2*du_k_val + du_kp1_val)
+                )),
+            )
+
+            # ∂²a_end(k-1)/∂var∂Δt_{k-1}
+            add_hess!(u_km1_v, dt_km1_v, μ_fwd * (-12*inv_Δt_km1_3))
+            add_hess!(u_k_v, dt_km1_v, μ_fwd * (12*inv_Δt_km1_3))
+            add_hess!(du_km1_v, dt_km1_v, μ_fwd * (-2*inv_Δt_km1_2))
+            add_hess!(du_k_v, dt_km1_v, μ_fwd * (-4*inv_Δt_km1_2))
+
+            # -∂²a_start(k)/∂var∂Δt_k
+            add_hess!(u_k_v, dt_k_v, μ_fwd * (-12*inv_Δt_k_3))
+            add_hess!(u_kp1_v, dt_k_v, μ_fwd * (12*inv_Δt_k_3))
+            add_hess!(du_k_v, dt_k_v, μ_fwd * (-4*inv_Δt_k_2))
+            add_hess!(du_kp1_v, dt_k_v, μ_fwd * (-2*inv_Δt_k_2))
+
+            constraint_idx += 1
+
+            # Backward inequality: g = -g_fwd, so Hessian is negated
+            @inbounds μ_bwd = μ[constraint_idx]
+
+            add_hess!(
+                dt_km1_v,
+                dt_km1_v,
+                -μ_bwd * (
+                    -36 * inv_Δt_km1_4 * (u_k_val - u_km1_val) +
+                    4 * inv_Δt_km1_3 * (du_km1_val + 2*du_k_val)
+                ),
+            )
+            add_hess!(
+                dt_k_v,
+                dt_k_v,
+                -μ_bwd * (-(
+                    36 * inv_Δt_k_4 * (u_kp1_val - u_k_val) -
+                    4 * inv_Δt_k_3 * (2*du_k_val + du_kp1_val)
+                )),
+            )
+            add_hess!(u_km1_v, dt_km1_v, -μ_bwd * (-12*inv_Δt_km1_3))
+            add_hess!(u_k_v, dt_km1_v, -μ_bwd * (12*inv_Δt_km1_3))
+            add_hess!(du_km1_v, dt_km1_v, -μ_bwd * (-2*inv_Δt_km1_2))
+            add_hess!(du_k_v, dt_km1_v, -μ_bwd * (-4*inv_Δt_km1_2))
+            add_hess!(u_k_v, dt_k_v, -μ_bwd * (-12*inv_Δt_k_3))
+            add_hess!(u_kp1_v, dt_k_v, -μ_bwd * (12*inv_Δt_k_3))
+            add_hess!(du_k_v, dt_k_v, -μ_bwd * (-4*inv_Δt_k_2))
+            add_hess!(du_kp1_v, dt_k_v, -μ_bwd * (-2*inv_Δt_k_2))
+
+            constraint_idx += 1
+        end
+    end
+
+    # === Bound inequalities: each run's leading a_start ===
+    for k in segs
+        (k == 1 || !in_seg[k-1]) || continue
+
+        inv_Δt_k = 1.0 / Δt[k]
+        inv_Δt_k_2 = inv_Δt_k * inv_Δt_k
+        inv_Δt_k_3 = inv_Δt_k_2 * inv_Δt_k
+        inv_Δt_k_4 = inv_Δt_k_3 * inv_Δt_k
+
+        for drive_idx = 1:n_drives
+            @inbounds begin
+                u_k_val = u[drive_idx, k]
+                u_kp1_val = u[drive_idx, k+1]
+                du_k_val = du[drive_idx, k]
+                du_kp1_val = du[drive_idx, k+1]
+            end
+
+            u_k_v = u_col(k, drive_idx)
+            u_kp1_v = u_col(k + 1, drive_idx)
+            du_k_v = du_col(k, drive_idx)
+            du_kp1_v = du_col(k + 1, drive_idx)
+            dt_k_v = dt_col(k)
+
+            # g = a_start - a_max, so ∂²g = ∂²a_start
+            @inbounds μ_pos = μ[constraint_idx]
+            add_hess!(
+                dt_k_v,
+                dt_k_v,
+                μ_pos * (
+                    36 * inv_Δt_k_4 * (u_kp1_val - u_k_val) -
+                    4 * inv_Δt_k_3 * (2*du_k_val + du_kp1_val)
+                ),
+            )
+            add_hess!(u_k_v, dt_k_v, μ_pos * (12*inv_Δt_k_3))
+            add_hess!(u_kp1_v, dt_k_v, μ_pos * (-12*inv_Δt_k_3))
+            add_hess!(du_k_v, dt_k_v, μ_pos * (4*inv_Δt_k_2))
+            add_hess!(du_kp1_v, dt_k_v, μ_pos * (2*inv_Δt_k_2))
+            constraint_idx += 1
+
+            # g = -a_start - a_max, so ∂²g = -∂²a_start
+            @inbounds μ_neg = μ[constraint_idx]
+            add_hess!(
+                dt_k_v,
+                dt_k_v,
+                -μ_neg * (
+                    36 * inv_Δt_k_4 * (u_kp1_val - u_k_val) -
+                    4 * inv_Δt_k_3 * (2*du_k_val + du_kp1_val)
+                ),
+            )
+            add_hess!(u_k_v, dt_k_v, -μ_neg * (12*inv_Δt_k_3))
+            add_hess!(u_kp1_v, dt_k_v, -μ_neg * (-12*inv_Δt_k_3))
+            add_hess!(du_k_v, dt_k_v, -μ_neg * (4*inv_Δt_k_2))
+            add_hess!(du_kp1_v, dt_k_v, -μ_neg * (2*inv_Δt_k_2))
+            constraint_idx += 1
+        end
+    end
+
+    # === Bound inequalities: a_end of every non-final segment of a run ===
+    for k in segs
+        (k + 1 <= N_timesteps - 1 && in_seg[k+1]) || continue
+        _hsa_add_a_end_hessian!(
+            add_hess!,
+            μ,
+            constraint_idx,
+            u,
+            du,
+            Δt,
+            k,
+            n_drives,
+            u_col,
+            du_col,
+            dt_col,
+        )
+        constraint_idx += 2 * n_drives
+    end
+
+    # === Bound inequalities: a_end of each run's final segment ===
+    for k in segs
+        (k + 1 > N_timesteps - 1 || !in_seg[k+1]) || continue
+        _hsa_add_a_end_hessian!(
+            add_hess!,
+            μ,
+            constraint_idx,
+            u,
+            du,
+            Δt,
+            k,
+            n_drives,
+            u_col,
+            du_col,
+            dt_col,
+        )
+        constraint_idx += 2 * n_drives
+    end
+
+    return nothing
+end
+
+# Evaluation wrappers for DirectTrajOpt
+"""
+    eval_jacobian(constraint, traj) -> SparseMatrixCSC
+
+The ASSEMBLED Jacobian entry point — unchanged in contract (this is what Ipopt/MadNLP
+and the backend's row-stacking consume). Served from the stencil table's cached sparse
+matrix: the pattern is built once at construction and only `nzval` is refreshed, so the
+returned matrix is the same object on every call and the call allocates nothing that
+grows with the knot count.
+
+`size(J) == (g_dim, traj.dim * traj.N + traj.global_dim)` — the FULL decision-vector
+width. Sizing it without the global columns made the row-stacking throw on any
+trajectory carrying free phases.
+"""
+function DirectTrajOpt.CommonInterface.eval_jacobian(
+    constraint::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+)
+    _hsa_refresh_coefficients!(traj.datavec, constraint.kinds, constraint.table)
+    return stencil_assemble!(constraint.table)
+end
+
+function DirectTrajOpt.CommonInterface.eval_hessian_of_lagrangian(
+    constraint::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    hess = zeros(length(constraint.hess_structure))
+    hessian_of_lagrangian!(hess, μ, constraint, traj)
+
+    # Convert to sparse matrix (lower triangular storage)
+    I_rows = [pair[1] for pair in constraint.hess_structure]
+    J_cols = [pair[2] for pair in constraint.hess_structure]
+
+    # Full decision-vector width, matching `eval_jacobian` and DirectTrajOpt's
+    # `Z_dim = traj.dim * traj.N + traj.global_dim` convention.
+    n = constraint.table.n_cols
+    M_lower = sparse(I_rows, J_cols, hess, n, n)
+
+    # Make symmetric: M = M_lower + M_lower' - diag(M_lower)
+    # This properly handles off-diagonal elements
+    M_sym = M_lower + M_lower' - spdiagm(diag(M_lower))
+
+    # Return sparse matrix for Ipopt compatibility
+    return M_sym
+end
+
+# ============================================================================= #
+#   Reference (pre-port) residual — the residual-semantics witness               #
+# ============================================================================= #
+#
+# Kept reachable so the port's residual can be checked against the implementation it
+# replaces, on randomised trajectories (#330 AC1). Reads the trajectory through the
+# named-component accessor exactly as the pre-port code did — which is why it is
+# test-only and on no hot path. All-segments only: the pre-port constraint had no
+# `segments` option.
+
+"""
+    _reference_evaluate!(g, constraint, traj)
+
+The pre-port residual, verbatim in formulation and row order. Test-only witness for
+"residual semantics unchanged"; requires `constraint.segments == 1:traj.N-1`.
+"""
+@views function _reference_evaluate!(
+    g::AbstractVector,
+    constraint::HermiteSmoothAccelerationConstraint,
+    traj::NamedTrajectory,
+)
+    @assert constraint.segments == collect(1:(traj.N-1)) "reference residual covers all segments only"
+
+    u = traj[constraint.control_name]
+    du = traj[constraint.derivative_name]
+    Δt = traj[constraint.timestep_name]
+
+    N_timesteps = traj.N
+    n_drives = constraint.n_drives
+    a_max = constraint.a_max
+
+    idx = 1
+
+    # === Continuity inequalities (double-sided) at interior knots ===
+    for k = 2:(N_timesteps-1)
+        inv_Δt_km1 = 1.0 / Δt[k-1]
+        inv_Δt_k = 1.0 / Δt[k]
+        inv_Δt_km1_2 = inv_Δt_km1 * inv_Δt_km1
+        inv_Δt_k_2 = inv_Δt_k * inv_Δt_k
+
+        for drive_idx = 1:n_drives
+            u_km1 = u[drive_idx, k-1]
+            u_k = u[drive_idx, k]
+            u_kp1 = u[drive_idx, k+1]
+            du_km1 = du[drive_idx, k-1]
+            du_k = du[drive_idx, k]
+            du_kp1 = du[drive_idx, k+1]
+
+            a_end_km1 =
+                -6 * inv_Δt_km1_2 * (u_k - u_km1) + 2 * inv_Δt_km1 * (du_km1 + 2*du_k)
+            a_start_k = 6 * inv_Δt_k_2 * (u_kp1 - u_k) - 2 * inv_Δt_k * (2*du_k + du_kp1)
+
+            g[idx] = a_end_km1 - a_start_k  # ≤ 0
+            idx += 1
+            g[idx] = a_start_k - a_end_km1  # ≤ 0
+            idx += 1
+        end
+    end
+
+    # === Bound inequalities at all knots ===
+
+    # Knot 1: a_start(segment 1)
+    inv_Δt_1 = 1.0 / Δt[1]
+    inv_Δt_1_2 = inv_Δt_1 * inv_Δt_1
+    for drive_idx = 1:n_drives
+        u_1 = u[drive_idx, 1]
+        u_2 = u[drive_idx, 2]
+        du_1 = du[drive_idx, 1]
+        du_2 = du[drive_idx, 2]
+
+        a = 6 * inv_Δt_1_2 * (u_2 - u_1) - 2 * inv_Δt_1 * (2*du_1 + du_2)
+
+        g[idx] = a - a_max      # ≤ 0
+        idx += 1
+        g[idx] = -a - a_max     # ≤ 0
+        idx += 1
+    end
+
+    # Interior knots: common acceleration (use a_end formula)
+    for k = 2:(N_timesteps-1)
+        inv_Δt_km1 = 1.0 / Δt[k-1]
+        inv_Δt_km1_2 = inv_Δt_km1 * inv_Δt_km1
+
+        for drive_idx = 1:n_drives
+            u_km1 = u[drive_idx, k-1]
+            u_k = u[drive_idx, k]
+            du_km1 = du[drive_idx, k-1]
+            du_k = du[drive_idx, k]
+
+            a = -6 * inv_Δt_km1_2 * (u_k - u_km1) + 2 * inv_Δt_km1 * (du_km1 + 2*du_k)
+
+            g[idx] = a - a_max      # ≤ 0
+            idx += 1
+            g[idx] = -a - a_max     # ≤ 0
+            idx += 1
+        end
+    end
+
+    # Knot N: a_end(segment N-1)
+    k = N_timesteps - 1
+    inv_Δt_k = 1.0 / Δt[k]
+    inv_Δt_k_2 = inv_Δt_k * inv_Δt_k
+    for drive_idx = 1:n_drives
+        u_k = u[drive_idx, k]
+        u_kp1 = u[drive_idx, k+1]
+        du_k = du[drive_idx, k]
+        du_kp1 = du[drive_idx, k+1]
+
+        a = -6 * inv_Δt_k_2 * (u_kp1 - u_k) + 2 * inv_Δt_k * (du_k + 2*du_kp1)
+
+        g[idx] = a - a_max      # ≤ 0
+        idx += 1
+        g[idx] = -a - a_max     # ≤ 0
+        idx += 1
+    end
+
+    return nothing
+end
+
+@testitem "HermiteSmoothAccelerationConstraint derivative validation" begin
+    using NamedTrajectories
+    using Piccolo
+    using DirectTrajOpt: test_constraint
+    using LinearAlgebra
+    using Random
+
+    # Seeded: the μ∂²g FD check sits near the tolerance (Hessian entries carry
+    # 1/Δt³ factors, so FD noise on O(10–100) entries approaches the 1e-3 atol);
+    # an unseeded fixture made this intermittently red in full-suite runs.
+    Random.seed!(1)
+
+    # Create trajectory with cubic spline pulse
+    N = 6
+    T = 2.0
+    times = collect(range(0, T, N))
+    n_drives = 2
+    u = randn(n_drives, N)
+    du = randn(n_drives, N) * 0.5
+
+    pulse = CubicSplinePulse(u, du, times)
+    sys = TransmonSystem(levels = 3)
+    U_goal = Matrix{ComplexF64}(I, 3, 3)
+    qtraj = UnitaryTrajectory(sys, pulse, U_goal)
+    traj = NamedTrajectory(qtraj, N)
+
+    # Create constraint
+    constraint = HermiteSmoothAccelerationConstraint(traj; a_max = 10.0)
+
+    # Validate Jacobian and Hessian against finite differences
+    # Use atol=1e-3 to accommodate finite difference precision on diagonal Hessian terms
+    test_constraint(constraint, traj; atol = 1e-3, show_jacobian_diff = true)
+end
+
+@testitem "#330 AC1/AC2: ported residual matches the reference; Jacobian matches forward-mode AD" begin
+    using NamedTrajectories
+
+    HermiteSmoothAccelerationConstraint,
+    evaluate!,
+    jacobian!,
+    jacobian_structure,
+    eval_jacobian,
+    _reference_evaluate!
+    using ForwardDiff
+    using SparseArrays
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(0x330AC12)
+
+    # Trajectory factory, with and without global variables. The globals case is the
+    # one that matters for the DERIVATIVE oracle — the pre-port implementation sized
+    # its Jacobian without the global columns, so parity against it proves nothing
+    # there. Forward-mode AD OF THE PORTED RESIDUAL is the oracle: everything here is
+    # closed-form, so a tolerance loose enough to absorb finite-difference truncation
+    # error is loose enough to hide a wrong stencil coefficient.
+    function fixture(N, n_drives; globals::Bool, segments = nothing)
+        comps = (
+            u = randn(n_drives, N),
+            du = randn(n_drives, N) * 0.5,
+            Δt = reshape(0.05 .+ 0.1 .* rand(N), 1, N),
+        )
+        traj =
+            globals ?
+            NamedTrajectory(
+                comps;
+                timestep = :Δt,
+                controls = :u,
+                global_data = [0.3, -0.8],
+                global_components = (ϕ = 1:2,),
+            ) : NamedTrajectory(comps; timestep = :Δt, controls = :u)
+        c =
+            isnothing(segments) ? HermiteSmoothAccelerationConstraint(traj; a_max = 7.0) :
+            HermiteSmoothAccelerationConstraint(traj; a_max = 7.0, segments = segments)
+        return traj, c
+    end
+
+    # ── AC1: residual semantics unchanged, to machine precision, on randomised
+    # trajectories. The reference is the pre-port implementation, kept reachable.
+    for trial = 1:4
+        N = rand(4:9)
+        nd = rand(1:3)
+        traj, c = fixture(N, nd; globals = false)
+        g_new = zeros(c.g_dim)
+        g_ref = zeros(c.g_dim)
+        evaluate!(g_new, c, traj)
+        _reference_evaluate!(g_ref, c, traj)
+        @test g_new == g_ref        # bit-identical: same formulation, same row order
+    end
+
+    # Same, with globals present (neither the formulation nor the reference reads them)
+    traj_g, c_g = fixture(7, 2; globals = true)
+    g_new = zeros(c_g.g_dim)
+    g_ref = zeros(c_g.g_dim)
+    evaluate!(g_new, c_g, traj_g)
+    _reference_evaluate!(g_ref, c_g, traj_g)
+    @test g_new == g_ref
+
+    # ── AC2: the assembled Jacobian matches forward-mode AD of the ported residual.
+    function ad_jacobian(traj, c)
+        n_data = traj.dim * traj.N
+        f =
+            Z -> begin
+                t = NamedTrajectory(
+                    traj;
+                    datavec = Z[1:n_data],
+                    global_data = Z[(n_data+1):end],
+                )
+                g = zeros(eltype(Z), c.g_dim)
+                evaluate!(g, c, t)
+                return g
+            end
+        return ForwardDiff.jacobian(f, collect(vec(traj)))
+    end
+
+    for (label, fx) in (
+        "no globals" => fixture(8, 2; globals = false),
+        "with globals" => fixture(8, 2; globals = true),
+        "segment subset" => fixture(10, 2; globals = true, segments = 3:7),
+        "split segment runs" => fixture(12, 1; globals = false, segments = [1, 2, 3, 7, 8]),
+    )
+        traj, c = fx
+        J = eval_jacobian(c, traj)
+        J_ad = ad_jacobian(traj, c)
+        @test size(J) == size(J_ad)      # includes the global columns
+        @test size(J, 2) == traj.dim * traj.N + traj.global_dim
+        @test maximum(abs, Matrix(J) - J_ad) < 1e-11 * max(1.0, maximum(abs, J_ad))
+
+        # The flat-value entry point agrees with the assembled one, entry for entry.
+        vals = zeros(length(jacobian_structure(c)))
+        jacobian!(vals, c, traj)
+        for (e, (r, col)) in enumerate(jacobian_structure(c))
+            @test vals[e] == J[r, col]
+        end
+    end
+
+    # A subset of segments really does constrain fewer rows, and the table enumerates
+    # its functionals from those actual rows.
+    traj_s, c_s = fixture(10, 2; globals = false, segments = 3:7)
+    @test c_s.g_dim == 4 * 5 * 2
+    @test c_s.table.n_functionals == 2 * 5 * 2
+    @test c_s.table.n_rows == c_s.g_dim
+
+    # ── AC5: the assembled entry point's sparsity structure — rows, columns AND their
+    # ORDER — is exactly the pre-port one. `jacobian_structure` is the upstream
+    # interior-point contract (Ipopt/MadNLP consume it positionally alongside
+    # `jacobian!`'s value vector), so a reordering would be a silent miscoupling rather
+    # than a test failure. Reconstructed here independently of the constructor, from the
+    # pre-port emission order: all continuity rows (±, per interior knot, per drive),
+    # then knot 1's a_start, then a_end at interior knots 2:N-1, then knot N's a_end.
+    let N = 7, nd = 2
+        traj, c = fixture(N, nd; globals = false)
+        u_c = traj.components[:u]
+        du_c = traj.components[:du]
+        dt_c = traj.components[:Δt]
+        ucol = (k, d) -> ((k - 1) * traj.dim) + u_c[d]
+        dcol = (k, d) -> ((k - 1) * traj.dim) + du_c[d]
+        tcol = k -> ((k - 1) * traj.dim) + dt_c[1]
+
+        expected = Tuple{Int,Int}[]
+        row = 0
+        emit! = cols -> begin
+            for _ = 1:2                       # the ± row pair
+                row += 1
+                for col in cols
+                    push!(expected, (row, col))
+                end
+            end
+        end
+        for k = 2:(N-1), d = 1:nd
+            emit!([
+                ucol(k - 1, d),
+                ucol(k, d),
+                ucol(k + 1, d),
+                dcol(k - 1, d),
+                dcol(k, d),
+                dcol(k + 1, d),
+                tcol(k - 1),
+                tcol(k),
+            ])
+        end
+        for d = 1:nd
+            emit!([ucol(1, d), ucol(2, d), dcol(1, d), dcol(2, d), tcol(1)])
+        end
+        for k = 2:(N-1), d = 1:nd
+            emit!([ucol(k - 1, d), ucol(k, d), dcol(k - 1, d), dcol(k, d), tcol(k - 1)])
+        end
+        for d = 1:nd
+            k = N - 1
+            emit!([ucol(k, d), ucol(k + 1, d), dcol(k, d), dcol(k + 1, d), tcol(k)])
+        end
+
+        @test jacobian_structure(c) == expected
+        @test row == c.g_dim
+    end
+end
+
+@testitem "#330 AC3: residual and Jacobian allocation are invariant to knot count" begin
+    using NamedTrajectories
+
+    HermiteSmoothAccelerationConstraint, evaluate!, jacobian!, eval_jacobian
+    using Random
+
+    # KNOT-FLATNESS, not zero allocation. The interface hands the constraint a
+    # trajectory whose `datavec` is an abstractly-typed field, so one dynamic access
+    # costs a constant floor no kernel work removes (ADR-0010 decision 6). What is
+    # asserted is that the floor is CONSTANT: an implementation that still reads the
+    # trajectory through the `Any`-inferred accessor, or rebuilds a hash lookup and a
+    # whole sparse matrix per call, grows linearly in N and fails the `==`.
+    #
+    # Shape copied from the dynamics-HVP gates (`#337 alloc:` in
+    # spline_integrator_ket.jl): local-scoped closures only (a callback at global scope
+    # captures `Any` and inflates the count), and the MINIMUM over repeats because
+    # `@allocated` sums across every thread in the process.
+    function measure(N)
+        Random.seed!(0x330A11C)
+        n_drives = 2
+        traj = NamedTrajectory(
+            (
+                u = randn(n_drives, N),
+                du = randn(n_drives, N),
+                Δt = reshape(fill(0.1, N), 1, N),
+            );
+            timestep = :Δt,
+            controls = :u,
+        )
+        c = HermiteSmoothAccelerationConstraint(traj; a_max = 10.0)
+        g = zeros(c.g_dim)
+        vals = zeros(length(c.jac_structure))
+        res = () -> evaluate!(g, c, traj)
+        jacv = () -> jacobian!(vals, c, traj)
+        asm = () -> eval_jacobian(c, traj)
+        best = f -> (f(); f(); minimum(@allocated(f()) for _ = 1:5))
+        return (residual = best(res), jacobian = best(jacv), assembled = best(asm))
+    end
+
+    N_SMALL, N_LARGE = 33, 129
+
+    # Process-level warmup over BOTH sizes before either is measured: the FIRST
+    # `@allocated` site in a process reports a different figure from every subsequent
+    # one, and with `==` as the assertion whichever size went first would otherwise
+    # carry that one-time step as phantom N-growth.
+    measure(N_SMALL)
+    measure(N_LARGE)
+
+    a = measure(N_SMALL)
+    b = measure(N_LARGE)
+
+    for k in (:residual, :jacobian, :assembled)
+        # INVARIANCE, not "less than before": a bound of that form is satisfied by an
+        # implementation that still allocates linearly in N.
+        @test getproperty(b, k) == getproperty(a, k)
+        # …plus a loose absolute ceiling, so the constant floor cannot creep either.
+        @test getproperty(b, k) <= 4096
+    end
+end
+
+@testitem "HermiteSmoothAccelerationConstraint basic" begin
+    using NamedTrajectories
+    using Piccolo
+    using LinearAlgebra
+
+    N = 5
+    T = 2.0
+    times = collect(range(0, T, N))
+    u = randn(2, N)
+    du = randn(2, N)
+
+    pulse = CubicSplinePulse(u, du, times)
+    sys = TransmonSystem(levels = 3)
+    U_goal = Matrix{ComplexF64}(I, 3, 3)
+    qtraj = UnitaryTrajectory(sys, pulse, U_goal)
+    traj = NamedTrajectory(qtraj, N)
+
+    constraint = HermiteSmoothAccelerationConstraint(traj; a_max = 10.0)
+
+    # Check dimensions - pure inequality formulation:
+    # - Continuity (double-sided): 2 * (N-2) * n_drives = 2 * 3 * 2 = 12
+    # - Bounds (double-sided): 2 * N * n_drives = 2 * 5 * 2 = 20
+    # - Total: 4 * (N-1) * n_drives = 4 * 4 * 2 = 32
+    n_drives = 2
+    N_segments = N - 1  # 4 segments
+    expected_total = 4 * N_segments * n_drives  # 32
+
+    @test constraint.g_dim == expected_total
+    @test constraint.equality == false  # Pure inequality
+    @test constraint.N_segments == N_segments
+
+    # The stencil table: one functional per unique scalar, two rows each (±).
+    @test constraint.table.n_rows == expected_total
+    @test constraint.table.n_functionals == expected_total ÷ 2
+    @test constraint.table.n_cols == traj.dim * traj.N + traj.global_dim
+    @test constraint.table.stencil_width == 1
+end
+
+@testitem "HermiteSmoothAccelerationConstraint constraint counts" begin
+    using NamedTrajectories
+    using Piccolo
+    using LinearAlgebra
+
+    # Test different trajectory sizes
+    for N in [4, 6, 10]
+        T = 2.0
+        times = collect(range(0, T, N))
+        n_drives = 2
+        u = randn(n_drives, N)
+        du = randn(n_drives, N)
+
+        pulse = CubicSplinePulse(u, du, times)
+        sys = TransmonSystem(levels = 3)
+        U_goal = Matrix{ComplexF64}(I, 3, 3)
+        qtraj = UnitaryTrajectory(sys, pulse, U_goal)
+        traj = NamedTrajectory(qtraj, N)
+
+        constraint = HermiteSmoothAccelerationConstraint(traj; a_max = 10.0)
+
+        # Expected counts - pure inequality formulation:
+        # - Continuity (double-sided): 2 * (N-2) * n_drives
+        # - Bounds (double-sided): 2 * N * n_drives
+        # - Total: 4 * (N-1) * n_drives
+        N_segments = N - 1
+        expected_total = 4 * N_segments * n_drives
+
+        @test constraint.equality == false
+        @test constraint.g_dim == expected_total
+        @test constraint.N_segments == N_segments
+
+        # Test evaluation produces correct sized output
+        g = zeros(constraint.g_dim)
+        evaluate!(g, constraint, traj)
+        @test length(g) == expected_total
+        @test all(isfinite.(g))
+    end
+end
+
+# ============================================================================= #
+#   Exact inequality HVP on the stencil table (#458)                            #
+# ============================================================================= #
+#
+# The assembled `hessian_of_lagrangian!` above stays on the `hess_structure` path for the
+# interior-point solvers. The MATRIX-FREE backend path consumes the per-functional action
+# below instead: `Σ_f ω_f ∇²F_f · v` over the table's functionals, the second-order
+# analogue of the #332 pairing (a functional's `±` row pair shares ONE functional, so one
+# weight contraction `ω_f = Σ_r sign_r w_r` serves both rows before any second-order work).
+# Every closed form here is the one `hessian_of_lagrangian!` already carries, re-expressed
+# as an ACTION — and the ForwardDiff oracle below is what keeps the two from drifting,
+# exactly as the residual witness does for the Jacobian.
+
+"""
+    _hsa_functional_hessian_action!(Hv, v, ω, kind, Z, cols, o)
+
+Add `ω · ∇²F_kind(x) · v` to `Hv` for one functional of the given kind, reading the
+iterate scalars from `Z` at the declared columns `cols[o+1…]`. ACCUMULATES. Allocation-free.
+
+The accelerations are linear in `u`/`du` and rational in `Δt`, so every second derivative
+carries a `Δt` index — exactly the entries `hessian_of_lagrangian!` writes. All closed
+forms follow that function (and the docstring above it); the ForwardDiff oracle testitem
+is the drift guard.
+"""
+@inline function _hsa_functional_hessian_action!(
+    Hv::AbstractVector{Float64},
+    v::AbstractVector{Float64},
+    ω::Float64,
+    kind::Int8,
+    Z::AbstractVector{Float64},
+    cols::Vector{Int},
+    o::Int,
+)
+    @inbounds if kind == HSA_JUMP
+        # F = a_end(k-1) − a_start(k), columns [u_{k-1},u_k,u_{k+1},du_{k-1},du_k,du_{k+1},Δt_{k-1},Δt_k]
+        u_km1 = Z[cols[o+1]]
+        u_k = Z[cols[o+2]]
+        u_kp1 = Z[cols[o+3]]
+        du_km1 = Z[cols[o+4]]
+        du_k = Z[cols[o+5]]
+        du_kp1 = Z[cols[o+6]]
+        i_km1 = 1.0 / Z[cols[o+7]]
+        i_k = 1.0 / Z[cols[o+8]]
+        i_km1_2 = i_km1 * i_km1
+        i_km1_3 = i_km1_2 * i_km1
+        i_km1_4 = i_km1_3 * i_km1
+        i_k_2 = i_k * i_k
+        i_k_3 = i_k_2 * i_k
+        i_k_4 = i_k_3 * i_k
+        vt_m1 = v[cols[o+7]]
+        vt_k = v[cols[o+8]]
+        # −a_start(k) part: every ∂²a_start entry negated.
+        h_k = -(36 * i_k_4 * (u_kp1 - u_k) - 4 * i_k_3 * (2 * du_k + du_kp1))
+        # a_end(k-1) part.
+        h_m1 = (-36 * i_km1_4 * (u_k - u_km1) + 4 * i_km1_3 * (du_km1 + 2 * du_k))
+        # Δt_{k-1} row/column (the a_end block only)
+        Hv[cols[o+7]] +=
+            ω * (
+                h_m1 * vt_m1 - 12 * i_km1_3 * v[cols[o+1]] + 12 * i_km1_3 * v[cols[o+2]] -
+                2 * i_km1_2 * v[cols[o+4]] - 4 * i_km1_2 * v[cols[o+5]]
+            )
+        # Δt_k row/column (the −a_start block only)
+        Hv[cols[o+8]] +=
+            ω * (
+                h_k * vt_k - 12 * i_k_3 * v[cols[o+2]] + 12 * i_k_3 * v[cols[o+3]] -
+                4 * i_k_2 * v[cols[o+5]] - 2 * i_k_2 * v[cols[o+6]]
+            )
+        # the shared u_k / du_k columns carry one entry from each block
+        Hv[cols[o+1]] += ω * (-12 * i_km1_3 * vt_m1)
+        Hv[cols[o+2]] += ω * (12 * i_km1_3 * vt_m1 - 12 * i_k_3 * vt_k)
+        Hv[cols[o+3]] += ω * (12 * i_k_3 * vt_k)
+        Hv[cols[o+4]] += ω * (-2 * i_km1_2 * vt_m1)
+        Hv[cols[o+5]] += ω * (-4 * i_km1_2 * vt_m1 - 4 * i_k_2 * vt_k)
+        Hv[cols[o+6]] += ω * (-2 * i_k_2 * vt_k)
+    else
+        # a_start / a_end over [u_a, u_b, du_a, du_b, Δt]
+        u_a = Z[cols[o+1]]
+        u_b = Z[cols[o+2]]
+        du_a = Z[cols[o+3]]
+        du_b = Z[cols[o+4]]
+        i = 1.0 / Z[cols[o+5]]
+        i2 = i * i
+        i3 = i2 * i
+        i4 = i3 * i
+        vt = v[cols[o+5]]
+        if kind == HSA_A_START
+            h = 36 * i4 * (u_b - u_a) - 4 * i3 * (2 * du_a + du_b)
+            c_ua = 12 * i3
+            c_ub = -12 * i3
+            c_dua = 4 * i2
+            c_dub = 2 * i2
+        else
+            h = -36 * i4 * (u_b - u_a) + 4 * i3 * (du_a + 2 * du_b)
+            c_ua = -12 * i3
+            c_ub = 12 * i3
+            c_dua = -2 * i2
+            c_dub = -4 * i2
+        end
+        Hv[cols[o+5]] +=
+            ω * (
+                h * vt +
+                c_ua * v[cols[o+1]] +
+                c_ub * v[cols[o+2]] +
+                c_dua * v[cols[o+3]] +
+                c_dub * v[cols[o+4]]
+            )
+        Hv[cols[o+1]] += ω * (c_ua * vt)
+        Hv[cols[o+2]] += ω * (c_ub * vt)
+        Hv[cols[o+3]] += ω * (c_dua * vt)
+        Hv[cols[o+4]] += ω * (c_dub * vt)
+    end
+    return nothing
+end
+
+function constraint_stencil_hvp!(
+    Hv::AbstractVector{Float64},
+    c::HermiteSmoothAccelerationConstraint,
+    w::AbstractVector{Float64},
+    v::AbstractVector{Float64},
+    x::AbstractVector{Float64},
+)
+    t = c.table
+    length(Hv) == t.n_cols || throw(
+        DimensionMismatch(
+            "Hv has length $(length(Hv)), expected the full decision width $(t.n_cols)",
+        ),
+    )
+    kinds = c.kinds
+    cols = t.cols
+    col_ptr = t.col_ptr
+    @inbounds for f in eachindex(kinds)
+        ω = stencil_functional_weight(t, w, f)
+        _hsa_functional_hessian_action!(Hv, v, ω, kinds[f], x, cols, col_ptr[f] - 1)
+    end
+    return nothing
+end
+
+supports_matrix_free_constraint_hvp(::HermiteSmoothAccelerationConstraint) = true
+
+@testitem "#458 HSA exact inequality HVP: FD parity of the weighted residual Hessian" begin
+    using NamedTrajectories
+
+    HermiteSmoothAccelerationConstraint,
+    constraint_stencil_hvp!,
+    supports_matrix_free_constraint_hvp,
+    evaluate!
+    using ForwardDiff
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(0x45800A1)
+
+    function fixture(N, n_drives; globals::Bool, segments = nothing)
+        comps = (
+            u = randn(n_drives, N),
+            du = randn(n_drives, N) * 0.5,
+            Δt = reshape(0.05 .+ 0.1 .* rand(N), 1, N),
+        )
+        traj =
+            globals ?
+            NamedTrajectory(
+                comps;
+                timestep = :Δt,
+                controls = :u,
+                global_data = [0.3, -0.8],
+                global_components = (ϕ = 1:2,),
+            ) : NamedTrajectory(comps; timestep = :Δt, controls = :u)
+        c =
+            isnothing(segments) ? HermiteSmoothAccelerationConstraint(traj; a_max = 7.0) :
+            HermiteSmoothAccelerationConstraint(traj; a_max = 7.0, segments = segments)
+        return traj, c
+    end
+
+    # The AD oracle: ∇²(wᵀg)(x) · v with g the residual, x the flat decision vector.
+    function oracle(traj, c, w, v)
+        n_data = traj.dim * traj.N
+        n_vars = n_data + traj.global_dim
+        gfunc =
+            Z -> begin
+                t = NamedTrajectory(
+                    traj;
+                    datavec = Z[1:n_data],
+                    global_data = Z[(n_data+1):end],
+                )
+                g = zeros(eltype(Z), c.g_dim)
+                evaluate!(g, c, t)
+                return dot(w, g)
+            end
+        x = collect(vec(traj))
+        return ForwardDiff.hessian(gfunc, x) * v, x, n_vars
+    end
+
+    for (label, fx) in (
+        "no globals" => fixture(8, 2; globals = false),
+        "with globals" => fixture(8, 2; globals = true),
+        "segment subset" => fixture(10, 2; globals = true, segments = 3:7),
+        "split runs, one drive" =>
+            fixture(9, 1; globals = false, segments = [1, 2, 3, 6, 7]),
+    )
+        traj, c = fx
+        @test supports_matrix_free_constraint_hvp(c) == true
+
+        w = randn(MersenneTwister(0x458A), c.g_dim)
+        n_vars = traj.dim * traj.N + traj.global_dim
+        v = randn(MersenneTwister(0x458B), n_vars)
+        Hv_ref, x, _ = oracle(traj, c, w, v)
+
+        # The action matches the exact Hessian of the weighted residual.
+        Hv = zeros(n_vars)
+        constraint_stencil_hvp!(Hv, c, w, v, x)
+        @test norm(Hv) > 0                    # not vacuous
+        @test norm(Hv - Hv_ref) <= 1e-8 * max(1.0, norm(Hv_ref))
+
+        # Linearity in the weights: w₁ + w₂ doubles through the contraction.
+        Hv_sum = zeros(n_vars)
+        constraint_stencil_hvp!(Hv_sum, c, 2.0 .* w, v, x)
+        @test norm(Hv_sum - 2.0 .* Hv) <= 1e-8 * max(1.0, norm(Hv))
+
+        # ACCUMULATES: a second call doubles the output.
+        constraint_stencil_hvp!(Hv, c, w, v, x)
+        @test norm(Hv - 2.0 .* Hv_ref) <= 1e-8 * max(1.0, norm(Hv_ref))
+
+        # A balanced ± pair on EVERY functional (each functional is a `±` pair here)
+        # contracts ω = 0 before any second-order work: exactly zero, everywhere.
+        w_bal = fill(0.75, c.g_dim)
+        Hv_bal = zeros(n_vars)
+        constraint_stencil_hvp!(Hv_bal, c, w_bal, v, x)
+        @test all(iszero, Hv_bal)
+
+        # Independent of the Jacobian coefficients: a refresh at a DIFFERENT iterate
+        # (rewriting `table.coeffs` for another x) must not move the HVP at this x.
+        using Piccolo: refresh_constraint_coefficients!
+        refresh_constraint_coefficients!(c, traj)          # coeffs at `x`
+        Hv_a = zeros(n_vars)
+        constraint_stencil_hvp!(Hv_a, c, w, v, x)
+        far = x .+ 0.5 .* randn(MersenneTwister(0x458C), n_vars)
+        far_traj = NamedTrajectory(
+            traj;
+            datavec = far[1:(traj.dim*traj.N)],
+            global_data = far[(traj.dim*traj.N+1):end],
+        )
+        refresh_constraint_coefficients!(c, far_traj)      # coeffs at `far`
+        Hv_b = zeros(n_vars)
+        constraint_stencil_hvp!(Hv_b, c, w, v, x)
+        @test Hv_a == Hv_b                 # bitwise: the HVP never reads `coeffs`
+    end
+end
+
+@testitem "#458 HSA inequality HVP: allocation is invariant to knot count" begin
+    using NamedTrajectories
+
+    HermiteSmoothAccelerationConstraint, constraint_stencil_hvp!
+    using Random
+
+    function measure(N)
+        Random.seed!(0x45800A2)
+        n_drives = 2
+        traj = NamedTrajectory(
+            (
+                u = randn(n_drives, N),
+                du = randn(n_drives, N),
+                Δt = reshape(fill(0.1, N), 1, N),
+            );
+            timestep = :Δt,
+            controls = :u,
+        )
+        c = HermiteSmoothAccelerationConstraint(traj; a_max = 10.0)
+        n_vars = traj.dim * traj.N + traj.global_dim
+        Hv = zeros(n_vars)
+        w = randn(c.g_dim)
+        v = randn(n_vars)
+        x = collect(vec(traj))
+        f = () -> constraint_stencil_hvp!(Hv, c, w, v, x)
+        f()
+        f()
+        return minimum(@allocated(f()) for _ = 1:5)
+    end
+
+    measure(33)
+    measure(129)
+    a = measure(33)
+    b = measure(129)
+    # KNOT-FLATNESS (ADR-0009 decision 3 / ADR-0010 decision 6): invariance, plus a
+    # loose absolute ceiling so the constant floor cannot creep either.
+    @test b == a
+    @test b <= 4096
+end

--- a/src/control/constraints_spline/nonlinear_knot_point_constraint.jl
+++ b/src/control/constraints_spline/nonlinear_knot_point_constraint.jl
@@ -1,0 +1,654 @@
+"""
+    OptimizedNonlinearKnotPointConstraint{F} <: AbstractNonlinearConstraint
+    Piccolo.Control.QuantumConstraints.SplineConstraints.NonlinearKnotPointConstraint{F} <: AbstractNonlinearConstraint
+
+**Optimized** constraint implementation with pre-allocated full sparse matrices.
+
+!!! note "Exported as OptimizedNonlinearKnotPointConstraint"
+    Exported (from Piccolo, slice 3c #431; re-exported by Piccolissimo) as
+    `OptimizedNonlinearKnotPointConstraint` to avoid shadowing
+    `DirectTrajOpt.NonlinearKnotPointConstraint`. Use either:
+    - `Piccolo.OptimizedNonlinearKnotPointConstraint` (exported, recommended)
+    - `Piccolo.Control.QuantumConstraints.SplineConstraints.NonlinearKnotPointConstraint` (internal name)
+
+# Optimization vs DirectTrajOpt Version
+
+DirectTrajOpt's version stores compact per-knot-point blocks and assembles them on each call.
+This Piccolissimo-originated version (Piccolo home since slice 3c, #431) pre-allocates the full sparse structure once and writes directly.
+
+**Performance Benefits:**
+- **`get_full_jacobian` / `get_full_hessian` are allocation-free** — they return the
+  pre-allocated reference, with no `spzeros` and no `vcat`
+- **10-100x less memory** (single sparse matrix vs N blocks + overhead)
+- **Cache-friendly**: ForwardDiff still operates on small variable blocks
+
+!!! warning "`jacobian!` is NOT zero-allocation"
+    This docstring claimed zero allocation for `jacobian!` as well. Measurement
+    contradicts it: `jacobian!` allocates a fresh ForwardDiff config plus a per-knot
+    `vcat` on every call, and reads the trajectory through the `Any`-inferred
+    `traj[t][name]` accessor — 133 kB at `N`=51 and 524 kB at `N`=201, i.e. **linear in
+    the knot count** (`evaluate!`: 75.9 kB → 299 kB, ~98% of it from the accessor's
+    boxing, not from the constraint algebra). Only `get_full_jacobian` /
+    `get_full_hessian` are allocation-free. See `docs/adr/0010` and CONTEXT.md's
+    "Optimized Constraints" correction; `HermiteSmoothAccelerationConstraint` shows the
+    go-forward design (a `ConstraintStencilTable`, knot-flat rather than
+    zero-allocation), and bringing this ForwardDiff-backed type to the same standard
+    needs cached differentiation configs and is deliberately not attempted here.
+
+# Fields
+- `g::F`: Constraint function mapping (variables..., params) -> constraint values
+- `var_names::Vector{Symbol}`: Names of trajectory variables the constraint depends on
+- `equality::Bool`: If true, g(x) = 0; if false, g(x) ≤ 0
+- `times::Vector{Int}`: Time indices where constraint is applied
+- `params::Vector`: Parameters for each time index (e.g., time-varying targets)
+- `g_dim::Int`: Dimension of constraint output at each knot point
+- `var_dim::Int`: Combined dimension of all constrained variables
+- `dim::Int`: Total constraint dimension (g_dim * length(times))
+- `∂g_full::SparseMatrixCSC{Float64, Int}`: Pre-allocated full Jacobian (dim × Z_dim)
+- `μ∂²g_full::SparseMatrixCSC{Float64, Int}`: Pre-allocated full Hessian (Z_dim × Z_dim)
+
+# Constructor
+
+The constructor signature is **identical** to DirectTrajOpt's version for drop-in compatibility:
+
+```julia
+OptimizedNonlinearKnotPointConstraint(
+    g::Function,
+    names::Union{Symbol, AbstractVector{Symbol}},
+    traj::NamedTrajectory;
+    equality::Bool=true,
+    times::AbstractVector{Int}=1:traj.N,
+    params::AbstractVector=fill(nothing, length(times)),
+    jacobian_structure::Union{Nothing, SparseMatrixCSC}=nothing,
+    hessian_structure::Union{Nothing, SparseMatrixCSC}=nothing,
+)
+```
+
+# Arguments
+- `g::Function`: Constraint function. For single variable: `g(x)`. For multiple: `g(x, u)` or `g(x_concat)`.
+- `names`: Variable name(s) to constrain. Single: `:x`. Multiple: `[:x, :u]`.
+- `traj::NamedTrajectory`: The trajectory on which the constraint is defined.
+
+# Keyword Arguments
+- `equality::Bool=true`: If true, enforces `g(x) = 0`. Otherwise `g(x) ≤ 0`.
+- `times::AbstractVector{Int}=1:traj.N`: Time indices where constraint is enforced.
+- `params::AbstractVector=fill(nothing, length(times))`: Per-knot-point parameters.
+- `jacobian_structure::Union{Nothing, SparseMatrixCSC}=nothing`: Custom sparsity pattern (g_dim × var_dim per block).
+- `hessian_structure::Union{Nothing, SparseMatrixCSC}=nothing`: Custom sparsity pattern (var_dim × var_dim per block).
+
+# Usage Examples
+
+```julia
+using Piccolo
+
+# Simple norm constraint
+constraint = OptimizedNonlinearKnotPointConstraint(
+    x -> [norm(x) - 1.0],
+    :x, traj;
+    equality=false
+)
+
+# Multi-variable constraint with separate arguments
+constraint = OptimizedNonlinearKnotPointConstraint(
+    (x, u) -> [x[1]^2 + u[1]^2 - 1.0],
+    [:x, :u], traj;
+    times=2:traj.N-1
+)
+
+# With custom sparsity (only first component matters)
+∂g_structure = sparse([1], [1], [1.0], 1, 2)  # 1×2, only (1,1) non-zero
+constraint = OptimizedNonlinearKnotPointConstraint(
+    u -> [u[1]^2 - 1.0],
+    :u, traj;
+    jacobian_structure=∂g_structure
+)
+```
+
+# Comparison with DirectTrajOpt
+
+```julia
+using DirectTrajOpt
+using Piccolo
+
+# DirectTrajOpt version (compact blocks, assembly on each call)
+dto_constraint = NonlinearKnotPointConstraint(g, :u, traj)  # Uses DTO version
+
+# The optimized version (pre-allocated full matrix, allocation-free `get_full_*`)
+pic_constraint = Piccolo.Control.QuantumConstraints.SplineConstraints.NonlinearKnotPointConstraint(g, :u, traj)
+
+# Both implement the same interface and work with DirectTrajOptProblem
+prob = DirectTrajOptProblem(traj, objective, integrators; 
+    constraints=[pic_constraint]  # Use optimized version
+)
+```
+"""
+struct NonlinearKnotPointConstraint{F} <: AbstractNonlinearConstraint
+    g::F
+    var_names::Vector{Symbol}
+    equality::Bool
+    times::Vector{Int}
+    params::Vector
+    g_dim::Int
+    var_dim::Int
+    dim::Int
+    ∂g_full::SparseMatrixCSC{Float64,Int}
+    μ∂²g_full::SparseMatrixCSC{Float64,Int}
+
+    function NonlinearKnotPointConstraint(
+        g::Function,
+        names::AbstractVector{Symbol},
+        traj::NamedTrajectory,
+        params::AbstractVector;
+        equality::Bool = true,
+        times::AbstractVector{Int} = 1:traj.N,
+        jacobian_structure::Union{Nothing,SparseMatrixCSC} = nothing,
+        hessian_structure::Union{Nothing,SparseMatrixCSC} = nothing,
+    )
+        @assert length(params) == length(times) "params must have the same length as times"
+
+        # Get component indices for all variables
+        x_comps = vcat([traj.components[name] for name in names]...)
+        var_dim = length(x_comps)
+
+        # Determine constraint dimension by evaluating with first parameter
+        Z⃗ = vec(traj)
+        x_slice_test = slice(1, x_comps, traj.dim)
+        test_result = g(Z⃗[x_slice_test], params[1])
+        @assert test_result isa AbstractVector{<:Real} "Constraint function must return a vector"
+        g_dim = length(test_result)
+
+        dim = g_dim * length(times)
+        Z_dim = traj.dim * traj.N + traj.global_dim
+
+        # Build full Jacobian structure
+        if !isnothing(jacobian_structure)
+            @assert size(jacobian_structure) == (g_dim, var_dim) "jacobian_structure must be (g_dim=$g_dim × var_dim=$var_dim)"
+
+            # Replicate block structure for all knot points
+            ∂g_full = spzeros(dim, Z_dim)
+            for (i, t) in enumerate(times)
+                row_range = slice(i, g_dim)
+                col_range = slice(t, x_comps, traj.dim)
+                ∂g_full[row_range, col_range] = jacobian_structure
+            end
+        else
+            # Default: assume all entries in each block may be non-zero
+            ∂g_full = spzeros(dim, Z_dim)
+            for (i, t) in enumerate(times)
+                row_range = slice(i, g_dim)
+                col_range = slice(t, x_comps, traj.dim)
+                ∂g_full[row_range, col_range] .= 1.0  # Mark structure
+            end
+        end
+
+        # Build full Hessian structure
+        if !isnothing(hessian_structure)
+            @assert size(hessian_structure) == (var_dim, var_dim) "hessian_structure must be (var_dim=$var_dim × var_dim=$var_dim)"
+
+            # Block diagonal structure
+            μ∂²g_full = spzeros(Z_dim, Z_dim)
+            for (i, t) in enumerate(times)
+                block_range = slice(t, x_comps, traj.dim)
+                μ∂²g_full[block_range, block_range] = hessian_structure
+            end
+        else
+            # Default: assume all entries in each block may be non-zero
+            μ∂²g_full = spzeros(Z_dim, Z_dim)
+            for (i, t) in enumerate(times)
+                block_range = slice(t, x_comps, traj.dim)
+                μ∂²g_full[block_range, block_range] .= 1.0  # Mark structure
+            end
+        end
+
+        return new{typeof(g)}(
+            g,
+            names,
+            equality,
+            times,
+            params,
+            g_dim,
+            var_dim,
+            dim,
+            ∂g_full,
+            μ∂²g_full,
+        )
+    end
+end
+
+# Convenience constructor without params - creates wrapper that ignores param argument
+function NonlinearKnotPointConstraint(
+    g::Function,
+    names::AbstractVector{Symbol},
+    traj::NamedTrajectory;
+    times::AbstractVector{Int} = 1:traj.N,
+    kwargs...,
+)
+    num_vars = length(names)
+
+    if num_vars == 1
+        # Single variable: g(x) where x is the variable values
+        params = [nothing for _ in times]
+        g_param = (x, _) -> g(x)
+        return NonlinearKnotPointConstraint(
+            g_param,
+            names,
+            traj,
+            params;
+            times = times,
+            kwargs...,
+        )
+    else
+        # Multiple variables: determine if g expects separate arguments or concatenated
+
+        # Get component ranges for splitting concatenated vector
+        comp_ranges = Vector{UnitRange{Int}}(undef, num_vars)
+        offset = 0
+        for (i, name) in enumerate(names)
+            comp_len = length(traj.components[name])
+            comp_ranges[i] = (offset+1):(offset+comp_len)
+            offset += comp_len
+        end
+
+        params = [nothing for _ in times]
+
+        # Test if g accepts separate arguments
+        Z⃗ = vec(traj)
+        x_comps = vcat([traj.components[name] for name in names]...)
+        x_slice = slice(1, x_comps, traj.dim)
+        test_vec = Z⃗[x_slice]
+        test_args = [test_vec[r] for r in comp_ranges]
+
+        accepts_separate_args = false
+        try
+            result = g(test_args...)
+            accepts_separate_args = result isa AbstractVector
+        catch
+            accepts_separate_args = false
+        end
+
+        if accepts_separate_args
+            # Wrapper that splits concatenated vector into separate arguments
+            g_param = function (x_concat, _)
+                args = [x_concat[r] for r in comp_ranges]
+                return g(args...)
+            end
+        else
+            # g expects a single concatenated vector
+            g_param = (x, _) -> g(x)
+        end
+
+        return NonlinearKnotPointConstraint(
+            g_param,
+            names,
+            traj,
+            params;
+            times = times,
+            kwargs...,
+        )
+    end
+end
+
+function NonlinearKnotPointConstraint(
+    g::Function,
+    name::Symbol,
+    traj::NamedTrajectory;
+    kwargs...,
+)
+    return NonlinearKnotPointConstraint(g, [name], traj; kwargs...)
+end
+
+# ----------------------------------------------------------------------------- #
+# Core Evaluation Methods
+# ----------------------------------------------------------------------------- #
+
+"""
+    evaluate!(values::AbstractVector, constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+Evaluate the constraint, storing results in-place in `values`.
+Part of the common interface with integrators.
+"""
+function CommonInterface.evaluate!(
+    values::AbstractVector,
+    constraint::NonlinearKnotPointConstraint,
+    traj::NamedTrajectory,
+)
+    @views for (i, t) ∈ enumerate(constraint.times)
+        x_vals = vcat([traj[t][name] for name in constraint.var_names]...)
+        values[slice(i, constraint.g_dim)] = constraint.g(x_vals, constraint.params[i])
+    end
+    return nothing
+end
+
+# ----------------------------------------------------------------------------- #
+# Optimized Jacobian Methods
+# ----------------------------------------------------------------------------- #
+
+"""
+    jacobian_structure(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+Return the sparsity structure of the full Jacobian (already stored).
+"""
+function jacobian_structure(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+    return constraint.∂g_full
+end
+
+"""
+    jacobian!(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+Compute Jacobian and store directly in pre-allocated `constraint.∂g_full`.
+
+Writes directly into the sparse matrix's `nzval`, so no matrix is assembled — but this
+call is **not** allocation-free: it builds a fresh ForwardDiff config and a per-knot
+`vcat`, and reads the trajectory through the `Any`-inferred accessor, for a cost linear
+in the knot count (133 kB at `N`=51, 524 kB at `N`=201). See the type's docstring.
+"""
+function DirectTrajOpt.Constraints.jacobian!(
+    constraint::NonlinearKnotPointConstraint,
+    traj::NamedTrajectory,
+)
+    # Zero out non-zero values
+    fill!(constraint.∂g_full.nzval, 0.0)
+
+    x_comps = vcat([traj.components[name] for name in constraint.var_names]...)
+
+    @views for (i, t) ∈ enumerate(constraint.times)
+        x_vals = vcat([traj[t][name] for name in constraint.var_names]...)
+        row_range = slice(i, constraint.g_dim)
+        col_range = slice(t, x_comps, traj.dim)
+
+        # Compute Jacobian directly into pre-allocated sparse matrix block
+        ForwardDiff.jacobian!(
+            constraint.∂g_full[row_range, col_range],
+            x -> constraint.g(x, constraint.params[i]),
+            x_vals,
+        )
+    end
+    return nothing
+end
+
+"""
+    get_full_jacobian(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+Return the full Jacobian (already computed and stored).
+**Allocation-free** - just returns a reference to the pre-allocated matrix. (This
+method, and `get_full_hessian`, are the only allocation-free ones on this type.)
+"""
+function DirectTrajOpt.Constraints.get_full_jacobian(
+    constraint::NonlinearKnotPointConstraint,
+    traj::NamedTrajectory,
+)
+    return constraint.∂g_full
+end
+
+"""
+    eval_jacobian(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+High-level method: compute and return the full Jacobian.
+Calls `jacobian!` then returns the pre-allocated matrix.
+"""
+function eval_jacobian(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+    jacobian!(constraint, traj)
+    return constraint.∂g_full
+end
+
+# ----------------------------------------------------------------------------- #
+# Optimized Hessian Methods
+# ----------------------------------------------------------------------------- #
+
+"""
+    hessian_structure(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+Return the sparsity structure of the full Hessian (already stored).
+"""
+function hessian_structure(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+    return constraint.μ∂²g_full
+end
+
+"""
+    hessian_of_lagrangian!(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory, μ::AbstractVector)
+
+Compute Hessian weighted by Lagrange multipliers, storing directly in `constraint.μ∂²g_full`.
+
+Writes directly into the sparse matrix's `nzval`, so no matrix is assembled — but, like
+`jacobian!`, this call is **not** allocation-free and its cost is linear in the knot
+count. See the type's docstring.
+"""
+function DirectTrajOpt.Constraints.hessian_of_lagrangian!(
+    constraint::NonlinearKnotPointConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    # Zero out non-zero values
+    fill!(constraint.μ∂²g_full.nzval, 0.0)
+
+    x_comps = vcat([traj.components[name] for name in constraint.var_names]...)
+
+    @views for (i, t) ∈ enumerate(constraint.times)
+        x_vals = vcat([traj[t][name] for name in constraint.var_names]...)
+        μₖ = μ[slice(i, constraint.g_dim)]
+        block_range = slice(t, x_comps, traj.dim)
+
+        # Compute Hessian directly into pre-allocated sparse matrix block
+        ForwardDiff.hessian!(
+            constraint.μ∂²g_full[block_range, block_range],
+            x -> μₖ' * constraint.g(x, constraint.params[i]),
+            x_vals,
+        )
+    end
+    return nothing
+end
+
+"""
+    get_full_hessian(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory)
+
+Return the full Hessian (already computed and stored).
+**Allocation-free** - just returns a reference to the pre-allocated matrix.
+"""
+function DirectTrajOpt.Constraints.get_full_hessian(
+    constraint::NonlinearKnotPointConstraint,
+    traj::NamedTrajectory,
+)
+    return constraint.μ∂²g_full
+end
+
+"""
+    eval_hessian_of_lagrangian(constraint::NonlinearKnotPointConstraint, traj::NamedTrajectory, μ::AbstractVector)
+
+High-level method: compute and return the full Hessian of the Lagrangian.
+Calls `hessian_of_lagrangian!` then returns the pre-allocated matrix.
+"""
+function eval_hessian_of_lagrangian(
+    constraint::NonlinearKnotPointConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    hessian_of_lagrangian!(constraint, traj, μ)
+    return constraint.μ∂²g_full
+end
+
+# ============================================================================= #
+# Tests
+# ============================================================================= #
+
+@testitem "OptimizedNonlinearKnotPointConstraint is exported correctly" begin
+    using Piccolo
+
+    # Verify the exported name exists and is the optimized version (with full sparse matrices)
+    @test isdefined(Piccolo, :OptimizedNonlinearKnotPointConstraint)
+
+    # Verify it's the optimized version (has ∂g_full field) not DirectTrajOpt version (has ∂gs field)
+    # We check this by looking at the fieldnames
+    fields = fieldnames(Piccolo.OptimizedNonlinearKnotPointConstraint)
+    @test :∂g_full ∈ fields  # the optimized version
+    @test :μ∂²g_full ∈ fields  # the optimized version
+    @test :∂gs ∉ fields  # NOT DirectTrajOpt's version
+end
+
+@testitem "NonlinearKnotPointConstraint - single variable" begin
+    # NonlinearKnotPointConstraint is defined in this file, available in test scope
+    # Import the interface functions from DirectTrajOpt where they're defined
+    using DirectTrajOpt.CommonInterface: evaluate!
+    import DirectTrajOpt.Constraints: get_full_jacobian, get_full_hessian
+    import DirectTrajOpt.Constraints: jacobian!, hessian_of_lagrangian!
+    using TrajectoryIndexingUtils
+    using LinearAlgebra
+    using NamedTrajectories
+    using ForwardDiff
+
+    # Create test trajectory
+    N = 10
+    traj = NamedTrajectory(
+        (x = randn(2, N), u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    g(a) = [norm(a) - 1.0]
+    times = 1:traj.N
+
+    NLC = Piccolo.OptimizedNonlinearKnotPointConstraint(
+        g,
+        :u,
+        traj;
+        times = times,
+        equality = false,
+    )
+    U_SLICE(k) = slice(k, traj.components[:u], traj.dim)
+
+    ĝ(Z⃗) = vcat([g(Z⃗[U_SLICE(k)]) for k ∈ times]...)
+
+    # Test evaluate!
+    δ = zeros(NLC.dim)
+    evaluate!(δ, NLC, traj)
+    @test δ ≈ ĝ(vec(traj))
+
+    # Test jacobian!
+    jacobian!(NLC, traj)
+    ∂g_full = get_full_jacobian(NLC, traj)
+    ∂g_autodiff = ForwardDiff.jacobian(ĝ, vec(traj))
+
+    @test ∂g_full[:, 1:(traj.dim*traj.N)] ≈ ∂g_autodiff
+
+    # Test hessian_of_lagrangian
+    μ = randn(length(times))
+    hessian_of_lagrangian!(NLC, traj, μ)
+    μ∂²g_full = get_full_hessian(NLC, traj)
+    hessian_autodiff = ForwardDiff.hessian(Z -> μ'ĝ(Z), vec(traj))
+
+    @test μ∂²g_full[1:(traj.dim*traj.N), 1:(traj.dim*traj.N)] ≈ hessian_autodiff
+end
+
+@testitem "NonlinearKnotPointConstraint - multiple variables" begin
+    # NonlinearKnotPointConstraint is defined in this file, available in test scope
+    # Import the interface functions from DirectTrajOpt where they're defined
+    using DirectTrajOpt.CommonInterface: evaluate!
+    import DirectTrajOpt.Constraints: get_full_jacobian, get_full_hessian
+    import DirectTrajOpt.Constraints: jacobian!, hessian_of_lagrangian!
+    using TrajectoryIndexingUtils
+    using LinearAlgebra
+    using NamedTrajectories
+    using ForwardDiff
+
+    N = 10
+    traj = NamedTrajectory(
+        (x = randn(2, N), u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Constraint with separate arguments
+    g_separate(x, u) = [x[1]^2 + x[2]^2 - 1.0, u[1] - 0.5]
+    times = 1:traj.N
+
+    NLC = Piccolo.OptimizedNonlinearKnotPointConstraint(
+        g_separate,
+        [:x, :u],
+        traj;
+        times = times,
+        equality = false,
+    )
+
+    X_SLICE(k) = slice(k, traj.components[:x], traj.dim)
+    U_SLICE(k) = slice(k, traj.components[:u], traj.dim)
+    ĝ(Z⃗) = vcat([g_separate(Z⃗[X_SLICE(k)], Z⃗[U_SLICE(k)]) for k ∈ times]...)
+
+    # Test evaluate!
+    δ = zeros(NLC.dim)
+    evaluate!(δ, NLC, traj)
+    @test δ ≈ ĝ(vec(traj))
+
+    # Test jacobian!
+    jacobian!(NLC, traj)
+    ∂g_full = get_full_jacobian(NLC, traj)
+    ∂g_autodiff = ForwardDiff.jacobian(ĝ, vec(traj))
+
+    @test ∂g_full[:, 1:(traj.dim*traj.N)] ≈ ∂g_autodiff
+
+    # Test hessian_of_lagrangian
+    μ = randn(2 * traj.N)
+    hessian_of_lagrangian!(NLC, traj, μ)
+    μ∂²g_full = get_full_hessian(NLC, traj)
+    hessian_autodiff = ForwardDiff.hessian(Z -> μ'ĝ(Z), vec(traj))
+
+    @test μ∂²g_full[1:(traj.dim*traj.N), 1:(traj.dim*traj.N)] ≈ hessian_autodiff
+end
+
+@testitem "NonlinearKnotPointConstraint - custom sparsity" begin
+    # NonlinearKnotPointConstraint is defined in this file, available in test scope
+    # Import the interface functions from DirectTrajOpt where they're defined
+    using DirectTrajOpt.CommonInterface: evaluate!
+    import DirectTrajOpt.Constraints: get_full_jacobian
+    import DirectTrajOpt.Constraints: jacobian!
+    using TrajectoryIndexingUtils
+    using LinearAlgebra
+    using NamedTrajectories
+    using ForwardDiff
+    using SparseArrays
+
+    N = 10
+    traj = NamedTrajectory(
+        (x = randn(2, N), u = randn(2, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Constraint that only depends on first component of u
+    g(u) = [u[1]^2 - 1.0]
+
+    g_dim = 1
+    var_dim = 2
+
+    # Custom sparsity: only first column non-zero
+    ∂g_structure = spzeros(g_dim, var_dim)
+    ∂g_structure[1, 1] = 1.0
+
+    # Custom Hessian sparsity: only (1,1) entry
+    μ∂²g_structure = spzeros(var_dim, var_dim)
+    μ∂²g_structure[1, 1] = 1.0
+
+    NLC = Piccolo.OptimizedNonlinearKnotPointConstraint(
+        g,
+        :u,
+        traj;
+        jacobian_structure = ∂g_structure,
+        hessian_structure = μ∂²g_structure,
+        equality = false,
+    )
+
+    # Verify sparsity structure was preserved
+    @test nnz(NLC.∂g_full) == traj.N  # Only N non-zeros (one per knot point)
+    @test nnz(NLC.μ∂²g_full) == traj.N  # Only N non-zeros (diagonal blocks)
+
+    # Test computation still works
+    U_SLICE(k) = slice(k, traj.components[:u], traj.dim)
+    ĝ(Z⃗) = vcat([g(Z⃗[U_SLICE(k)]) for k ∈ 1:traj.N]...)
+
+    δ = zeros(NLC.dim)
+    evaluate!(δ, NLC, traj)
+    @test δ ≈ ĝ(vec(traj))
+
+    jacobian!(NLC, traj)
+    ∂g_full = get_full_jacobian(NLC, traj)
+    ∂g_autodiff = ForwardDiff.jacobian(ĝ, vec(traj))
+    @test ∂g_full[:, 1:(traj.dim*traj.N)] ≈ ∂g_autodiff
+end

--- a/src/control/constraints_spline/nonlinear_segment_constraint.jl
+++ b/src/control/constraints_spline/nonlinear_segment_constraint.jl
@@ -1,0 +1,654 @@
+"""
+    NonlinearSegmentConstraint{F} <: AbstractNonlinearConstraint
+
+Constraint applied to trajectory segments (between adjacent knot points k and k+1).
+
+Similar to `NonlinearKnotPointConstraint` but evaluates constraints on intervals between
+knot points rather than at individual points. Useful for enforcing properties like:
+- Cubic spline extrema remain bounded
+- Monotonicity between knots
+- Maximum curvature constraints
+- Any property requiring access to both k and k+1
+
+# Architecture
+
+Follows the integrator pattern for accessing adjacent knot points. The constraint function
+receives variables from BOTH knot points k and k+1, just like `BilinearIntegrator` does.
+
+**Jacobian structure spans two knot points:**
+```julia
+∂g[segment_slice, slice(k, 1:2*traj.dim, traj.dim)] = jacobian_of_g_wrt_[zₖ, zₖ₊₁]
+```
+
+This enables efficient parallel evaluation (segments don't overlap in Jacobian) and
+reuses the proven integrator architecture.
+
+# Fields
+- `g::F`: Constraint function `g(varsₖ, varsₖ₊₁, params) -> vector`
+- `var_names::Vector{Symbol}`: Variable names to extract from trajectory
+- `equality::Bool`: If true, g = 0; if false, g ≤ 0
+- `segments::Vector{Int}`: Segment indices (segment k connects knots k and k+1)
+- `params::Vector`: Per-segment parameters (e.g., bounds, timestep)
+- `g_dim::Int`: Constraint output dimension per segment
+- `var_dim::Int`: Combined dimension of variables (from a single knot point)
+- `dim::Int`: Total constraint dimension (g_dim * length(segments))
+- `∂g_full::SparseMatrixCSC{Float64, Int}`: Pre-allocated Jacobian
+- `μ∂²g_full::SparseMatrixCSC{Float64, Int}`: Pre-allocated Hessian
+
+# Constructor
+
+```julia
+NonlinearSegmentConstraint(
+    g::Function,
+    names::Union{Symbol, AbstractVector{Symbol}},
+    traj::NamedTrajectory;
+    equality::Bool=true,
+    segments::AbstractVector{Int}=1:traj.N-1,
+    params::AbstractVector=fill(nothing, length(segments)),
+    jacobian_structure::Union{Nothing, SparseMatrixCSC}=nothing,
+    hessian_structure::Union{Nothing, SparseMatrixCSC}=nothing,
+)
+```
+
+# Arguments
+- `g::Function`: Constraint function with signature:
+  - `g(varsₖ, varsₖ₊₁, param) -> Vector` for constraints with params
+  - `g(varsₖ, varsₖ₊₁) -> Vector` for constraints without params
+  where `varsₖ` and `varsₖ₊₁` are extracted variables from knot points k and k+1
+- `names`: Variable name(s) to extract. Single `:u` or multiple `[:u, :du]`
+- `traj`: Trajectory defining the optimization problem
+
+# Keyword Arguments
+- `equality::Bool=true`: Constraint type (equality vs inequality)
+- `segments::AbstractVector{Int}=1:traj.N-1`: Segment indices to constrain
+- `params::AbstractVector=fill(nothing, length(segments))`: Per-segment parameters
+- `jacobian_structure`: Custom sparsity (g_dim × 2*var_dim per segment block)
+- `hessian_structure`: Custom sparsity (2*var_dim × 2*var_dim per segment block)
+
+# Examples
+
+## Cubic Spline Boundedness
+```julia
+# Ensure spline stays in [-1, 1] between all knots
+function spline_bound_constraint(varsₖ, varsₖ₊₁, params)
+    u_min, u_max, Δt = params
+    u_k, du_k = varsₖ[1:end÷2], varsₖ[end÷2+1:end]
+    u_kp1, du_kp1 = varsₖ₊₁[1:end÷2], varsₖ₊₁[end÷2+1:end]
+    
+    # Find extrema in [0, 1] for cubic Hermite spline
+    extrema_vals = find_cubic_extrema(u_k, u_kp1, du_k, du_kp1, Δt)
+    
+    # Return inequality constraints: u_min ≤ u(τ) ≤ u_max
+    return [u_min .- extrema_vals; extrema_vals .- u_max]
+end
+
+constraint = NonlinearSegmentConstraint(
+    spline_bound_constraint,
+    [:u, :du],
+    traj;
+    equality=false,
+    params=[(u_min, u_max, traj.Δt[k]) for k in 1:traj.N-1]
+)
+```
+
+## Monotonicity Constraint
+```julia
+# Ensure control is monotonically increasing
+function monotonic_constraint(varsₖ, varsₖ₊₁, param)
+    u_k = varsₖ[1]
+    u_kp1 = varsₖ₊₁[1]
+    return [u_kp1 - u_k]  # u_{k+1} ≥ u_k
+end
+
+constraint = NonlinearSegmentConstraint(
+    monotonic_constraint,
+    :u,
+    traj;
+    equality=false
+)
+```
+
+## Sufficient Condition for Bounds (Conservative)
+```julia
+# Limit slope magnitude based on distance to bounds
+function sufficient_bound_constraint(varsₖ, varsₖ₊₁, params)
+    u_min, u_max, C, Δt = params
+    u_k, du_k = varsₖ[1:end÷2], varsₖ[end÷2+1:end]
+    
+    gap_to_max = u_max .- u_k
+    gap_to_min = u_k .- u_min
+    max_slope = C .* min.(gap_to_max, gap_to_min) ./ Δt
+    
+    # Inequality: max_slope - |du_k| ≥ 0
+    return max_slope .- abs.(du_k)
+end
+
+constraint = NonlinearSegmentConstraint(
+    sufficient_bound_constraint,
+    [:u, :du],
+    traj;
+    equality=false,
+    params=[(u_min, u_max, 2.0, traj.Δt[k]) for k in 1:traj.N-1]
+)
+```
+"""
+struct NonlinearSegmentConstraint{F} <: AbstractNonlinearConstraint
+    g::F
+    var_names::Vector{Symbol}
+    equality::Bool
+    segments::Vector{Int}
+    params::Vector
+    g_dim::Int
+    var_dim::Int
+    dim::Int
+    ∂g_full::SparseMatrixCSC{Float64,Int}
+    μ∂²g_full::SparseMatrixCSC{Float64,Int}
+
+    function NonlinearSegmentConstraint(
+        g::Function,
+        names::AbstractVector{Symbol},
+        traj::NamedTrajectory,
+        params::AbstractVector;
+        equality::Bool = true,
+        segments::AbstractVector{Int} = 1:(traj.N-1),
+        jacobian_structure::Union{Nothing,SparseMatrixCSC} = nothing,
+        hessian_structure::Union{Nothing,SparseMatrixCSC} = nothing,
+    )
+        @assert length(params) == length(segments) "params must have same length as segments"
+        @assert all(1 .<= segments .< traj.N) "segment indices must be in [1, N-1]"
+
+        # Get component indices for all variables
+        var_comps = vcat([traj.components[name] for name in names]...)
+        var_dim = length(var_comps)
+
+        # Determine constraint dimension by evaluating with first parameter
+        Z⃗ = vec(traj)
+        varsₖ = Z⃗[slice(segments[1], var_comps, traj.dim)]
+        varsₖ₊₁ = Z⃗[slice(segments[1]+1, var_comps, traj.dim)]
+
+        # Try calling with or without params
+        test_result = if isnothing(params[1])
+            g(varsₖ, varsₖ₊₁)
+        else
+            g(varsₖ, varsₖ₊₁, params[1])
+        end
+
+        @assert test_result isa AbstractVector{<:Real} "Constraint function must return a vector"
+        g_dim = length(test_result)
+
+        dim = g_dim * length(segments)
+        Z_dim = traj.dim * traj.N + traj.global_dim
+
+        # Build full Jacobian structure
+        # Each segment block is g_dim × (2*var_dim) spanning [zₖ, zₖ₊₁]
+        if !isnothing(jacobian_structure)
+            @assert size(jacobian_structure) == (g_dim, 2*var_dim) "jacobian_structure must be g_dim × 2*var_dim"
+            # Replicate custom structure for all segments
+            ∂g_rows = Int[]
+            ∂g_cols = Int[]
+            for (seg_idx, k) in enumerate(segments)
+                # Map segment constraint index to full constraint vector
+                constraint_offset = (seg_idx - 1) * g_dim
+
+                for (row, col, _) in zip(findnz(jacobian_structure)...)
+                    # Determine if column is in zₖ or zₖ₊₁
+                    if col <= var_dim
+                        # Column in zₖ
+                        comp_idx = var_comps[col]
+                        Z_idx = (k - 1) * traj.dim + comp_idx
+                    else
+                        # Column in zₖ₊₁
+                        comp_idx = var_comps[col-var_dim]
+                        Z_idx = k * traj.dim + comp_idx
+                    end
+                    push!(∂g_rows, constraint_offset + row)
+                    push!(∂g_cols, Z_idx)
+                end
+            end
+            ∂g_full = sparse(∂g_rows, ∂g_cols, ones(length(∂g_rows)), dim, Z_dim)
+        else
+            # Default: dense blocks (g_dim × 2*var_dim per segment)
+            ∂g_rows = Int[]
+            ∂g_cols = Int[]
+            for (seg_idx, k) in enumerate(segments)
+                constraint_offset = (seg_idx - 1) * g_dim
+                for row = 1:g_dim
+                    # Columns for zₖ
+                    for comp_idx in var_comps
+                        Z_idx = (k - 1) * traj.dim + comp_idx
+                        push!(∂g_rows, constraint_offset + row)
+                        push!(∂g_cols, Z_idx)
+                    end
+                    # Columns for zₖ₊₁
+                    for comp_idx in var_comps
+                        Z_idx = k * traj.dim + comp_idx
+                        push!(∂g_rows, constraint_offset + row)
+                        push!(∂g_cols, Z_idx)
+                    end
+                end
+            end
+            ∂g_full = sparse(∂g_rows, ∂g_cols, ones(length(∂g_rows)), dim, Z_dim)
+        end
+
+        # Build full Hessian structure
+        # Each segment block couples (2*var_dim × 2*var_dim) variables
+        if !isnothing(hessian_structure)
+            @assert size(hessian_structure) == (2*var_dim, 2*var_dim) "hessian_structure must be 2*var_dim × 2*var_dim"
+            # Replicate custom structure for all segments
+            μ∂²g_rows = Int[]
+            μ∂²g_cols = Int[]
+            for k in segments
+                # Map variables to trajectory indices
+                Z_indices_k = [(k - 1) * traj.dim + comp for comp in var_comps]
+                Z_indices_kp1 = [k * traj.dim + comp for comp in var_comps]
+                Z_indices = vcat(Z_indices_k, Z_indices_kp1)
+
+                for (row, col, _) in zip(findnz(hessian_structure)...)
+                    push!(μ∂²g_rows, Z_indices[row])
+                    push!(μ∂²g_cols, Z_indices[col])
+                end
+            end
+            μ∂²g_full = sparse(μ∂²g_rows, μ∂²g_cols, ones(length(μ∂²g_rows)), Z_dim, Z_dim)
+        else
+            # Default: dense blocks (2*var_dim × 2*var_dim per segment)
+            μ∂²g_rows = Int[]
+            μ∂²g_cols = Int[]
+            for k in segments
+                Z_indices_k = [(k - 1) * traj.dim + comp for comp in var_comps]
+                Z_indices_kp1 = [k * traj.dim + comp for comp in var_comps]
+                Z_indices = vcat(Z_indices_k, Z_indices_kp1)
+
+                for row_idx in Z_indices
+                    for col_idx in Z_indices
+                        push!(μ∂²g_rows, row_idx)
+                        push!(μ∂²g_cols, col_idx)
+                    end
+                end
+            end
+            μ∂²g_full = sparse(μ∂²g_rows, μ∂²g_cols, ones(length(μ∂²g_rows)), Z_dim, Z_dim)
+        end
+
+        return new{typeof(g)}(
+            g,
+            names,
+            equality,
+            collect(segments),
+            params,
+            g_dim,
+            var_dim,
+            dim,
+            ∂g_full,
+            μ∂²g_full,
+        )
+    end
+end
+
+# Single variable name convenience constructor
+function NonlinearSegmentConstraint(
+    g::Function,
+    name::Symbol,
+    traj::NamedTrajectory,
+    params::AbstractVector;
+    kwargs...,
+)
+    return NonlinearSegmentConstraint(g, [name], traj, params; kwargs...)
+end
+
+# No-params convenience constructor
+function NonlinearSegmentConstraint(
+    g::Function,
+    names::Union{Symbol,AbstractVector{Symbol}},
+    traj::NamedTrajectory;
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+    kwargs...,
+)
+    params = fill(nothing, length(segments))
+    return NonlinearSegmentConstraint(
+        g,
+        names,
+        traj,
+        params;
+        segments = segments,
+        kwargs...,
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Interface Implementation
+# ----------------------------------------------------------------------------- #
+
+"""
+    evaluate!(values::AbstractVector, constraint::NonlinearSegmentConstraint, traj::NamedTrajectory)
+
+Evaluate constraint on all segments in parallel.
+"""
+function evaluate!(
+    values::AbstractVector,
+    constraint::NonlinearSegmentConstraint,
+    traj::NamedTrajectory,
+)
+    Z⃗ = vec(traj)
+    var_comps = vcat([traj.components[name] for name in constraint.var_names]...)
+
+    Threads.@threads for (seg_idx, k) in collect(enumerate(constraint.segments))
+        # Extract variables from both knot points
+        varsₖ = Z⃗[slice(k, var_comps, traj.dim)]
+        varsₖ₊₁ = Z⃗[slice(k+1, var_comps, traj.dim)]
+
+        # Evaluate constraint
+        result = if isnothing(constraint.params[seg_idx])
+            constraint.g(varsₖ, varsₖ₊₁)
+        else
+            constraint.g(varsₖ, varsₖ₊₁, constraint.params[seg_idx])
+        end
+
+        # Write to output
+        offset = (seg_idx - 1) * constraint.g_dim
+        values[(offset+1):(offset+constraint.g_dim)] .= result
+    end
+
+    return nothing
+end
+
+"""
+    jacobian_structure(constraint::NonlinearSegmentConstraint)
+
+Return pre-allocated Jacobian structure.
+"""
+function jacobian_structure(constraint::NonlinearSegmentConstraint)
+    return constraint.∂g_full
+end
+
+"""
+    jacobian!(constraint::NonlinearSegmentConstraint, traj::NamedTrajectory)
+
+Compute Jacobian using ForwardDiff on each segment block.
+"""
+function jacobian!(constraint::NonlinearSegmentConstraint, traj::NamedTrajectory)
+    Z⃗ = vec(traj)
+    var_comps = vcat([traj.components[name] for name in constraint.var_names]...)
+    ∂g = constraint.∂g_full
+
+    # Zero out (preserve structure)
+    ∂g.nzval .= 0.0
+
+    Threads.@threads for (seg_idx, k) in collect(enumerate(constraint.segments))
+        # Extract indices for this segment's block in full Jacobian
+        constraint_slice = (seg_idx - 1) * constraint.g_dim .+ (1:constraint.g_dim)
+        Z_slice_k = slice(k, var_comps, traj.dim)
+        Z_slice_kp1 = slice(k+1, var_comps, traj.dim)
+        Z_slice_segment = vcat(Z_slice_k, Z_slice_kp1)
+
+        # Create local Jacobian block (g_dim × 2*var_dim)
+        ∂g_local = zeros(constraint.g_dim, 2*constraint.var_dim)
+
+        # Compute Jacobian via ForwardDiff
+        ForwardDiff.jacobian!(
+            ∂g_local,
+            vars_concat -> begin
+                varsₖ = vars_concat[1:constraint.var_dim]
+                varsₖ₊₁ = vars_concat[(constraint.var_dim+1):end]
+                if isnothing(constraint.params[seg_idx])
+                    return constraint.g(varsₖ, varsₖ₊₁)
+                else
+                    return constraint.g(varsₖ, varsₖ₊₁, constraint.params[seg_idx])
+                end
+            end,
+            Z⃗[Z_slice_segment],
+        )
+
+        # Map local block to full sparse matrix
+        # This is safe for parallel writes because segments don't overlap
+        for (local_row, constraint_row) in enumerate(constraint_slice)
+            for local_col = 1:(2*constraint.var_dim)
+                if local_col <= constraint.var_dim
+                    Z_col = Z_slice_k[local_col]
+                else
+                    Z_col = Z_slice_kp1[local_col-constraint.var_dim]
+                end
+
+                # Find the position in sparse matrix
+                for idx in nzrange(∂g, Z_col)
+                    if ∂g.rowval[idx] == constraint_row
+                        ∂g.nzval[idx] = ∂g_local[local_row, local_col]
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    return nothing
+end
+
+"""
+    hessian_structure(constraint::NonlinearSegmentConstraint)
+
+Return pre-allocated Hessian structure.
+"""
+function hessian_structure(constraint::NonlinearSegmentConstraint)
+    return constraint.μ∂²g_full
+end
+
+"""
+    hessian_of_lagrangian(constraint::NonlinearSegmentConstraint, traj::NamedTrajectory, μ::AbstractVector)
+
+Compute Hessian of Lagrangian using ForwardDiff on each segment block.
+"""
+function hessian_of_lagrangian(
+    constraint::NonlinearSegmentConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    Z⃗ = vec(traj)
+    var_comps = vcat([traj.components[name] for name in constraint.var_names]...)
+    μ∂²g = constraint.μ∂²g_full
+
+    # Zero out (preserve structure)
+    μ∂²g.nzval .= 0.0
+
+    for (seg_idx, k) in enumerate(constraint.segments)
+        # Extract multipliers for this segment
+        μ_seg = μ[((seg_idx-1)*constraint.g_dim+1):(seg_idx*constraint.g_dim)]
+
+        # Skip if multipliers are zero
+        if norm(μ_seg) < 1e-16
+            continue
+        end
+
+        # Extract indices
+        Z_slice_k = slice(k, var_comps, traj.dim)
+        Z_slice_kp1 = slice(k+1, var_comps, traj.dim)
+        Z_slice_segment = vcat(Z_slice_k, Z_slice_kp1)
+
+        # Compute weighted Hessian via ForwardDiff
+        μ∂²g_local = ForwardDiff.hessian(
+            vars_concat -> begin
+                varsₖ = vars_concat[1:constraint.var_dim]
+                varsₖ₊₁ = vars_concat[(constraint.var_dim+1):end]
+                g_result = if isnothing(constraint.params[seg_idx])
+                    constraint.g(varsₖ, varsₖ₊₁)
+                else
+                    constraint.g(varsₖ, varsₖ₊₁, constraint.params[seg_idx])
+                end
+                return dot(μ_seg, g_result)
+            end,
+            Z⃗[Z_slice_segment],
+        )
+
+        # Map local block to full sparse matrix
+        for local_row = 1:(2*constraint.var_dim)
+            for local_col = 1:(2*constraint.var_dim)
+                Z_row = Z_slice_segment[local_row]
+                Z_col = Z_slice_segment[local_col]
+
+                # Find the position in sparse matrix
+                for idx in nzrange(μ∂²g, Z_col)
+                    if μ∂²g.rowval[idx] == Z_row
+                        μ∂²g.nzval[idx] += μ∂²g_local[local_row, local_col]
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    return nothing
+end
+
+# Convenience methods for CommonInterface
+function get_full_jacobian(constraint::NonlinearSegmentConstraint, traj::NamedTrajectory)
+    return constraint.∂g_full
+end
+
+function get_full_hessian(constraint::NonlinearSegmentConstraint, traj::NamedTrajectory)
+    return constraint.μ∂²g_full
+end
+
+function eval_jacobian(constraint::NonlinearSegmentConstraint, traj::NamedTrajectory)
+    jacobian!(constraint, traj)
+    return constraint.∂g_full
+end
+
+function eval_hessian_of_lagrangian(
+    constraint::NonlinearSegmentConstraint,
+    traj::NamedTrajectory,
+    μ::AbstractVector,
+)
+    hessian_of_lagrangian(constraint, traj, μ)
+    return constraint.μ∂²g_full
+end
+
+# ----------------------------------------------------------------------------- #
+# Tests
+# ----------------------------------------------------------------------------- #
+
+@testitem "NonlinearSegmentConstraint - basic functionality" begin
+    using NamedTrajectories
+    using SparseArrays
+    using LinearAlgebra
+    using Piccolo: NonlinearSegmentConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!, jacobian_structure
+    using DirectTrajOpt.Constraints: jacobian!
+    using DirectTrajOpt.CommonInterface: hessian_structure, hessian_of_lagrangian
+    using DirectTrajOpt.Constraints: get_full_jacobian, get_full_hessian
+
+    # Create simple trajectory with u and du
+    N = 10
+    u_dim = 2
+    traj = NamedTrajectory(
+        (u = randn(u_dim, N), du = randn(u_dim, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Simple constraint: u_{k+1} - u_k ≥ 0 (monotonicity)
+    function monotonic(varsₖ, varsₖ₊₁)
+        u_k = varsₖ[1:2]
+        u_kp1 = varsₖ₊₁[1:2]
+        return u_kp1 - u_k  # Should be ≥ 0
+    end
+
+    constraint = NonlinearSegmentConstraint(monotonic, [:u, :du], traj; equality = false)
+
+    # Test dimensions
+    @test constraint.g_dim == u_dim
+    @test constraint.var_dim == 2 * u_dim  # u and du
+    @test constraint.dim == u_dim * (N - 1)
+    @test length(constraint.segments) == N - 1
+
+    # Test evaluate!
+    values = zeros(constraint.dim)
+    evaluate!(values, constraint, traj)
+    @test length(values) == constraint.dim
+
+    # Test Jacobian structure
+    ∂g = jacobian_structure(constraint)
+    @test size(∂g) == (constraint.dim, traj.dim * traj.N + traj.global_dim)
+    @test nnz(∂g) > 0
+
+    # Test Jacobian computation
+    jacobian!(constraint, traj)
+    ∂g_eval = get_full_jacobian(constraint, traj)
+    @test ∂g_eval === constraint.∂g_full
+
+    # Test Hessian structure
+    μ∂²g = hessian_structure(constraint)
+    @test size(μ∂²g) ==
+          (traj.dim * traj.N + traj.global_dim, traj.dim * traj.N + traj.global_dim)
+
+    # Test Hessian computation
+    μ = randn(constraint.dim)
+    hessian_of_lagrangian(constraint, traj, μ)
+    μ∂²g_eval = get_full_hessian(constraint, traj)
+    @test μ∂²g_eval === constraint.μ∂²g_full
+end
+
+@testitem "NonlinearSegmentConstraint - with parameters" begin
+    using NamedTrajectories
+    using LinearAlgebra
+    using Piccolo: NonlinearSegmentConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+
+    N = 5
+    traj = NamedTrajectory(
+        (u = randn(1, N), du = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Constraint with time-varying target
+    function target_constraint(varsₖ, varsₖ₊₁, target)
+        u_kp1 = varsₖ₊₁[1]
+        return [abs(u_kp1) - target]  # |u| ≤ target
+    end
+
+    # N-1 segments need N-1 targets
+    targets = collect(range(1.0, 3.0, length = N-1))  # Different target per segment
+
+    constraint = NonlinearSegmentConstraint(
+        target_constraint,
+        [:u, :du],
+        traj,
+        targets;
+        equality = false,
+    )
+
+    @test length(constraint.params) == N - 1
+    @test constraint.params == targets
+
+    # Evaluate
+    values = zeros(constraint.dim)
+    evaluate!(values, constraint, traj)
+    @test length(values) == N - 1
+end
+
+@testitem "NonlinearSegmentConstraint - subset of segments" begin
+    using NamedTrajectories
+    using Piccolo: NonlinearSegmentConstraint
+    using DirectTrajOpt.CommonInterface: jacobian_structure
+
+    N = 20
+    traj = NamedTrajectory(
+        (u = randn(1, N), du = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Only constrain middle segments
+    segments = 5:15
+
+    function simple_constraint(varsₖ, varsₖ₊₁)
+        return [varsₖ₊₁[1] - varsₖ[1]]
+    end
+
+    constraint =
+        NonlinearSegmentConstraint(simple_constraint, [:u, :du], traj; segments = segments)
+
+    @test length(constraint.segments) == length(segments)
+    @test constraint.dim == length(segments)
+
+    # Verify only specified segments are in Jacobian structure
+    ∂g = jacobian_structure(constraint)
+    @test size(∂g, 1) == length(segments)
+end

--- a/src/control/constraints_spline/spline_bound_constraints.jl
+++ b/src/control/constraints_spline/spline_bound_constraints.jl
@@ -1,0 +1,920 @@
+# ----------------------------------------------------------------------------- #
+# Approach 1: Analytical Extrema Constraints (Exact)
+# ----------------------------------------------------------------------------- #
+
+"""
+    CubicSplineExtremaConstraint(
+        traj::NamedTrajectory,
+        u_bounds::Tuple{Real, Real};
+        control_name::Symbol=:u,
+        segments::AbstractVector{Int}=1:traj.N-1
+    )
+
+Create segment constraints ensuring cubic spline remains bounded via analytical extrema.
+
+This is the **exact** approach: finds critical points where du/dτ = 0 and constrains
+the spline value at those points.
+
+# Arguments
+- `traj`: Trajectory with cubic spline pulse (must have :u and :du components)
+- `u_bounds`: (u_min, u_max) bounds for the control
+
+# Keyword Arguments
+- `control_name`: Name of control variable (default :u)
+- `segments`: Which segments to constrain (default: all)
+
+# Returns
+`NonlinearSegmentConstraint` that can be added to a `DirectTrajOptProblem`.
+
+# Example
+```julia
+using Piccolo
+
+# Create spline pulse problem
+qcp = SplinePulseProblem(qtraj, N; Q=100.0, R=1e-2)
+traj = get_trajectory(qcp)
+
+# Add bound constraints
+u_min, u_max = -10.0, 10.0
+constraint = CubicSplineExtremaConstraint(traj, (u_min, u_max))
+
+# Recreate problem with constraint
+prob = DirectTrajOptProblem(
+    traj, 
+    qcp.objective, 
+    qcp.integrators;
+    constraints=vcat(qcp.constraints, [constraint])
+)
+```
+
+# Mathematical Details
+
+For each segment k → k+1, the constraint finds all critical points τ* ∈ (0,1) where
+du/dτ = 0 by solving a quadratic equation. It then evaluates u(τ*) at each critical
+point and imposes:
+
+```
+u_min ≤ u(τ*) ≤ u_max  for all critical points
+```
+
+This ensures the spline remains bounded throughout each segment.
+
+# Performance
+- Per-segment evaluation: ~10-50 μs (quadratic solve + evaluations)
+- Differentiable via ForwardDiff (implicit function theorem applies)
+- Typically 0-2 critical points per segment
+"""
+function CubicSplineExtremaConstraint(
+    traj::NamedTrajectory,
+    u_bounds::Tuple{Real,Real};
+    control_name::Symbol = :u,
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+)
+    u_min, u_max = u_bounds
+    du_name = Symbol(:d, control_name)
+
+    @assert control_name ∈ traj.names "Control $control_name not found in trajectory"
+    @assert du_name ∈ traj.names "Derivative $du_name not found in trajectory"
+    @assert traj.timestep ∈ traj.names "Timestep not found in trajectory"
+
+    n_drives = traj.dims[control_name]
+
+    # Constraint function: check extrema for each drive
+    # Each drive gets 8 constraints: 2 endpoints + up to 2 critical points, each with 2 bounds
+    # This gives a fixed dimension: 8 * n_drives per segment
+    function extrema_constraint(varsₖ, varsₖ₊₁, params)
+        u_min, u_max, Δt = params
+
+        # Split variables
+        n = length(varsₖ) ÷ 2
+        u_k = varsₖ[1:n]
+        du_k = varsₖ[(n+1):end]
+        u_kp1 = varsₖ₊₁[1:n]
+        du_kp1 = varsₖ₊₁[(n+1):end]
+
+        # Generic type for ForwardDiff compatibility
+        T = eltype(varsₖ)
+        constraints = T[]
+
+        for i = 1:n
+            # Always check exactly 4 points: 2 endpoints + 2 potential critical points
+            # This ensures fixed constraint dimension
+
+            # Endpoints (always exist)
+            u_vals = [u_k[i], u_kp1[i]]
+
+            # Find critical points
+            τ_crits = find_cubic_critical_points(u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+
+            # Evaluate at critical points (pad with endpoints if fewer than 2 critical points)
+            while length(τ_crits) < 2
+                push!(τ_crits, 0.5)  # Use midpoint as dummy (will be feasible if endpoints are)
+            end
+
+            for τ in τ_crits[1:2]  # Take at most 2 critical points
+                u_τ = evaluate_hermite_spline(τ, u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+                push!(u_vals, u_τ)
+            end
+
+            # Create 8 constraints per drive: 4 points × 2 bounds each
+            # Inequality constraints: u_min ≤ u(τ) ≤ u_max
+            # Reformulated as: u_min - u(τ) ≤ 0 and u(τ) - u_max ≤ 0
+            for u_val in u_vals
+                push!(constraints, u_min - u_val)  # u_min ≤ u
+                push!(constraints, u_val - u_max)  # u ≤ u_max
+            end
+        end
+
+        return constraints
+    end
+
+    # Create parameters for each segment
+    params = [(u_min, u_max, traj[k].timestep) for k in segments]
+
+    return NonlinearSegmentConstraint(
+        extrema_constraint,
+        [control_name, du_name],
+        traj,
+        params;
+        equality = false,  # Inequality constraints
+        segments = segments,
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Approach 2: Sufficient Conditions (Conservative)
+# ----------------------------------------------------------------------------- #
+
+"""
+    CubicSplineSufficientBoundConstraint(
+        traj::NamedTrajectory,
+        u_bounds::Tuple{Real, Real};
+        control_name::Symbol=:u,
+        safety_factor::Real=2.0,
+        segments::AbstractVector{Int}=1:traj.N-1
+    )
+
+Create segment constraints ensuring cubic spline remains bounded via sufficient conditions.
+
+This is the **conservative** approach: limits the slope magnitude based on distance
+to bounds. Guarantees boundedness but may be overly restrictive.
+
+# Arguments
+- `traj`: Trajectory with cubic spline pulse
+- `u_bounds`: (u_min, u_max) bounds for the control
+
+# Keyword Arguments
+- `control_name`: Name of control variable (default :u)
+- `safety_factor`: Multiplier for slope limit (default 2.0)
+- `segments`: Which segments to constrain (default: all)
+
+# Returns
+`NonlinearSegmentConstraint` that can be added to problem.
+
+# Example
+```julia
+# More conservative than extrema constraint, but simpler
+constraint = CubicSplineSufficientBoundConstraint(
+    traj, (-10.0, 10.0);
+    safety_factor=1.5  # Lower = more conservative
+)
+```
+
+# Mathematical Details
+
+For each knot k, the constraint enforces:
+
+```
+|du_k| ≤ C * min(u_max - u_k, u_k - u_min) / Δt
+```
+
+where C is the safety factor. This ensures the tangent at each knot point cannot
+"escape" the bounds within one time step.
+
+**Pros:**
+- Simple to evaluate (no critical point search)
+- Always convex
+- Faster than analytical extrema
+
+**Cons:**
+- Conservative (excludes some feasible solutions)
+- May require tuning safety factor
+
+# Safety Factor Guidelines
+- `C = 1.0`: Very conservative, nearly monotonic
+- `C = 2.0`: Moderate (recommended default)
+- `C = 3.0`: Less conservative, allows more curvature
+"""
+function CubicSplineSufficientBoundConstraint(
+    traj::NamedTrajectory,
+    u_bounds::Tuple{Real,Real};
+    control_name::Symbol = :u,
+    safety_factor::Real = 2.0,
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+)
+    u_min, u_max = u_bounds
+    du_name = Symbol(:d, control_name)
+
+    @assert control_name ∈ traj.names "Control $control_name not found in trajectory"
+    @assert du_name ∈ traj.names "Derivative $du_name not found in trajectory"
+    @assert safety_factor > 0 "safety_factor must be positive"
+
+    n_drives = traj.dims[control_name]
+
+    # Constraint function: limit slope based on gap to bounds
+    function sufficient_constraint(varsₖ, varsₖ₊₁, params)
+        u_min, u_max, C, Δt = params
+
+        # Split variables (only need varsₖ for this constraint)
+        n = length(varsₖ) ÷ 2
+        u_k = varsₖ[1:n]
+        du_k = varsₖ[(n+1):end]
+
+        # Generic type for ForwardDiff compatibility
+        T = eltype(varsₖ)
+        constraints = T[]
+
+        for i = 1:n
+            gap_to_max = u_max - u_k[i]
+            gap_to_min = u_k[i] - u_min
+            min_gap = min(gap_to_max, gap_to_min)
+
+            # Maximum allowed slope magnitude
+            max_slope = C * min_gap / Δt
+
+            # Inequality: |du_k| − max_slope ≤ 0 (backend convention: feasible ⟺ residual ≤ 0)
+            push!(constraints, abs(du_k[i]) - max_slope)
+        end
+
+        return constraints
+    end
+
+    # Create parameters for each segment
+    params = [(u_min, u_max, safety_factor, traj[k].timestep) for k in segments]
+
+    return NonlinearSegmentConstraint(
+        sufficient_constraint,
+        [control_name, du_name],
+        traj,
+        params;
+        equality = false,  # Inequality constraints
+        segments = segments,
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Multi-drive convenience constructors
+# ----------------------------------------------------------------------------- #
+
+"""
+    CubicSplineExtremaConstraint(
+        traj::NamedTrajectory,
+        u_bounds::Vector{Tuple{Real, Real}};
+        control_name::Symbol=:u,
+        segments::AbstractVector{Int}=1:traj.N-1
+    )
+
+Create extrema constraints with per-drive bounds.
+
+# Example
+```julia
+# Different bounds for different drives
+bounds = [(-5.0, 5.0), (-10.0, 10.0), (-8.0, 8.0)]
+constraint = CubicSplineExtremaConstraint(traj, bounds)
+```
+"""
+function CubicSplineExtremaConstraint(
+    traj::NamedTrajectory,
+    u_bounds::Vector{<:Tuple{Real,Real}};
+    control_name::Symbol = :u,
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+)
+    du_name = Symbol(:d, control_name)
+    n_drives = traj.dims[control_name]
+
+    @assert length(u_bounds) == n_drives "Must provide bounds for each drive"
+
+    # Fixed dimension: 8 constraints per drive (2 endpoints + 2 critical points, each with 2 bounds)
+    function extrema_constraint_multi(varsₖ, varsₖ₊₁, params)
+        u_bounds_vec, Δt = params
+
+        n = length(varsₖ) ÷ 2
+        u_k = varsₖ[1:n]
+        du_k = varsₖ[(n+1):end]
+        u_kp1 = varsₖ₊₁[1:n]
+        du_kp1 = varsₖ₊₁[(n+1):end]
+
+        # Generic type for ForwardDiff compatibility
+        T = eltype(varsₖ)
+        constraints = T[]
+
+        for i = 1:n
+            u_min, u_max = u_bounds_vec[i]
+
+            # Always check exactly 4 points: 2 endpoints + 2 potential critical points
+            u_vals = [u_k[i], u_kp1[i]]
+
+            # Find critical points
+            τ_crits = find_cubic_critical_points(u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+
+            # Pad with midpoint if fewer than 2 critical points
+            while length(τ_crits) < 2
+                push!(τ_crits, 0.5)
+            end
+
+            for τ in τ_crits[1:2]
+                u_τ = evaluate_hermite_spline(τ, u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+                push!(u_vals, u_τ)
+            end
+
+            # 8 constraints per drive
+            for u_val in u_vals
+                push!(constraints, u_min - u_val)
+                push!(constraints, u_val - u_max)
+            end
+        end
+
+        return constraints
+    end
+
+    params = [(u_bounds, traj[k].timestep) for k in segments]
+
+    return NonlinearSegmentConstraint(
+        extrema_constraint_multi,
+        [control_name, du_name],
+        traj,
+        params;
+        equality = false,
+        segments = segments,
+    )
+end
+
+"""
+    CubicSplineSufficientBoundConstraint(
+        traj::NamedTrajectory,
+        u_bounds::Vector{Tuple{Real, Real}};
+        control_name::Symbol=:u,
+        safety_factor::Real=2.0,
+        segments::AbstractVector{Int}=1:traj.N-1
+    )
+
+Create sufficient bound constraints with per-drive bounds.
+"""
+function CubicSplineSufficientBoundConstraint(
+    traj::NamedTrajectory,
+    u_bounds::Vector{<:Tuple{Real,Real}};
+    control_name::Symbol = :u,
+    safety_factor::Real = 2.0,
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+)
+    du_name = Symbol(:d, control_name)
+    n_drives = traj.dims[control_name]
+
+    @assert length(u_bounds) == n_drives "Must provide bounds for each drive"
+
+    function sufficient_constraint_multi(varsₖ, varsₖ₊₁, params)
+        u_bounds_vec, C, Δt = params
+
+        n = length(varsₖ) ÷ 2
+        u_k = varsₖ[1:n]
+        du_k = varsₖ[(n+1):end]
+
+        # Generic type for ForwardDiff compatibility
+        T = eltype(varsₖ)
+        constraints = T[]
+
+        for i = 1:n
+            u_min, u_max = u_bounds_vec[i]
+            gap_to_max = u_max - u_k[i]
+            gap_to_min = u_k[i] - u_min
+            min_gap = min(gap_to_max, gap_to_min)
+            max_slope = C * min_gap / Δt
+
+            # |du_k| − max_slope ≤ 0 (backend convention: feasible ⟺ residual ≤ 0)
+            push!(constraints, abs(du_k[i]) - max_slope)
+        end
+
+        return constraints
+    end
+
+    params = [(u_bounds, safety_factor, traj[k].timestep) for k in segments]
+
+    return NonlinearSegmentConstraint(
+        sufficient_constraint_multi,
+        [control_name, du_name],
+        traj,
+        params;
+        equality = false,
+        segments = segments,
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Approach 3: Slope/Derivative Extrema Constraints
+# ----------------------------------------------------------------------------- #
+
+"""
+    CubicSplineSlopeConstraint(
+        traj::NamedTrajectory,
+        du_bounds::Tuple{Real, Real};
+        control_name::Symbol=:u,
+        segments::AbstractVector{Int}=1:traj.N-1
+    )
+
+Create segment constraints ensuring cubic spline derivative (slope) remains bounded.
+
+This finds critical points where d²u/dt² = 0 and constrains the slope at those points
+and at segment endpoints.
+
+# Arguments
+- `traj`: Trajectory with cubic spline pulse (must have :u and :du components)
+- `du_bounds`: (du_min, du_max) bounds for the derivative
+
+# Keyword Arguments
+- `control_name`: Name of control variable (default :u)
+- `segments`: Which segments to constrain (default: all)
+
+# Returns
+`NonlinearSegmentConstraint` that can be added to a `DirectTrajOptProblem`.
+
+# Example
+```julia
+# Constrain slope to ±5
+du_bounds = (-5.0, 5.0)
+slope_constraint = CubicSplineSlopeConstraint(traj, du_bounds)
+
+prob = DirectTrajOptProblem(
+    traj, obj, integrators;
+    constraints=[slope_constraint]
+)
+```
+
+# Note
+Returns 4 constraints per drive per segment:
+- 2 endpoints (k and k+1)
+- Up to 1 interior critical point (padded to fixed size with midpoint)
+- Each checked against both bounds (lower and upper)
+"""
+function CubicSplineSlopeConstraint(
+    traj::NamedTrajectory,
+    du_bounds::Tuple{Real,Real};
+    control_name::Symbol = :u,
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+)
+    du_name = Symbol(:d, control_name)
+
+    # Verify required components exist
+    @assert control_name ∈ traj.names "Trajectory must have $control_name component"
+    @assert du_name ∈ traj.names "Trajectory must have $du_name component"
+    @assert :Δt ∈ traj.names "Trajectory must have Δt component"
+
+    du_min, du_max = du_bounds
+
+    n_drives = traj.dims[control_name]
+
+    function slope_constraint(varsₖ, varsₖ₊₁, (du_bounds, Δt))
+        # Split variables: assume [u..., du...] concatenated
+        n = length(varsₖ) ÷ 2
+        u_k = varsₖ[1:n]
+        du_k = varsₖ[(n+1):end]
+        u_kp1 = varsₖ₊₁[1:n]
+        du_kp1 = varsₖ₊₁[(n+1):end]
+
+        T = eltype(varsₖ)
+        constraints = T[]
+
+        for i = 1:n
+            # Find critical point of derivative (where d²u/dt² = 0)
+            τ_crits = find_slope_critical_points(u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+
+            # Collect evaluation points: endpoints + critical point
+            τ_evals = T[0.0, 1.0]
+            if !isempty(τ_crits)
+                push!(τ_evals, τ_crits[1])
+            else
+                # Pad with midpoint for fixed dimension
+                push!(τ_evals, 0.5)
+            end
+
+            # Evaluate slope at each point and constrain
+            for τ in τ_evals
+                slope =
+                    evaluate_hermite_derivative(τ, u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+
+                # Two inequality constraints per evaluation point. Backend convention:
+                # feasible ⟺ residual ≤ 0 (matches the AL's max(0, μ+ρc) penalty and the
+                # bounds rows; the previous sign was inverted, making feasible slopes read
+                # as violations of |du_bound| and crushing the pulse flat).
+                push!(constraints, du_bounds[1] - slope)  # du_min − slope ≤ 0 ⟺ slope ≥ du_min
+                push!(constraints, slope - du_bounds[2])  # slope − du_max ≤ 0 ⟺ slope ≤ du_max
+            end
+        end
+
+        # Returns 3 eval points × 2 bounds × n_drives constraints
+        return constraints
+    end
+
+    params = [(du_bounds, traj[k].timestep) for k in segments]
+
+    return NonlinearSegmentConstraint(
+        slope_constraint,
+        [control_name, du_name],
+        traj,
+        params;
+        equality = false,
+        segments = segments,
+    )
+end
+
+"""
+    CubicSplineSlopeConstraint(
+        traj::NamedTrajectory,
+        du_bounds::Vector{Tuple{Real, Real}};
+        control_names::Vector{Symbol}=[:u],
+        segments::AbstractVector{Int}=1:traj.N-1
+    )
+
+Multi-drive version for constraining slopes of multiple control variables.
+
+# Arguments
+- `traj`: Trajectory with spline pulse
+- `du_bounds`: Vector of (du_min, du_max) for each drive
+
+# Example
+```julia
+# Different bounds for each drive
+du_bounds = [(-5.0, 5.0), (-3.0, 3.0)]
+control_names = [:u1, :u2]
+slope_constraint = CubicSplineSlopeConstraint(traj, du_bounds; control_names)
+```
+"""
+function CubicSplineSlopeConstraint(
+    traj::NamedTrajectory,
+    du_bounds::Vector{Tuple{T,T}};
+    control_names::Vector{Symbol} = [:u],
+    segments::AbstractVector{Int} = 1:(traj.N-1),
+) where {T<:Real}
+
+    du_names = [Symbol(:d, name) for name in control_names]
+
+    # Verify all required components exist
+    for (name, du_name) in zip(control_names, du_names)
+        @assert name ∈ traj.names "Trajectory must have $name component"
+        @assert du_name ∈ traj.names "Trajectory must have $du_name component"
+    end
+    @assert :Δt ∈ traj.names "Trajectory must have Δt component"
+
+    # Calculate total number of drives across all control variables
+    total_drives = sum(traj.dims[name] for name in control_names)
+
+    function slope_constraint_multi(varsₖ, varsₖ₊₁, (du_bounds_vec, Δt))
+        # Split variables: [all u's..., all du's...]  
+        n = length(varsₖ) ÷ 2
+        u_k = varsₖ[1:n]
+        du_k = varsₖ[(n+1):end]
+        u_kp1 = varsₖ₊₁[1:n]
+        du_kp1 = varsₖ₊₁[(n+1):end]
+
+        ElemType = eltype(varsₖ)
+        constraints = ElemType[]
+
+        # Iterate over all drives
+        for i = 1:n
+            # Find the corresponding bounds
+            bounds = du_bounds_vec[i]
+
+            τ_crits = find_slope_critical_points(u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+
+            τ_evals = ElemType[0.0, 1.0]
+            if !isempty(τ_crits)
+                push!(τ_evals, τ_crits[1])
+            else
+                push!(τ_evals, 0.5)
+            end
+
+            for τ in τ_evals
+                slope =
+                    evaluate_hermite_derivative(τ, u_k[i], u_kp1[i], du_k[i], du_kp1[i], Δt)
+                # feasible ⟺ residual ≤ 0 (backend convention; see CubicSplineSlopeConstraint)
+                push!(constraints, bounds[1] - slope)  # du_min − slope ≤ 0
+                push!(constraints, slope - bounds[2])  # slope − du_max ≤ 0
+            end
+        end
+
+        return constraints
+    end
+
+    params = [(du_bounds, traj[k].timestep) for k in segments]
+
+    return NonlinearSegmentConstraint(
+        slope_constraint_multi,
+        vcat(control_names, du_names),
+        traj,
+        params;
+        equality = false,
+        segments = segments,
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Tests
+# ----------------------------------------------------------------------------- #
+
+@testitem "Hermite spline math utilities" begin
+    # Define functions locally for testing
+    function hermite_basis_functions(τ)
+        τ² = τ * τ
+        τ³ = τ² * τ
+        h00 = 2τ³ - 3τ² + 1
+        h10 = τ³ - 2τ² + τ
+        h01 = -2τ³ + 3τ²
+        h11 = τ³ - τ²
+        return (h00, h10, h01, h11)
+    end
+
+    function evaluate_hermite_spline(τ, u_k, u_kp1, du_k, du_kp1, Δt)
+        h00, h10, h01, h11 = hermite_basis_functions(τ)
+        return h00 * u_k + h10 * Δt * du_k + h01 * u_kp1 + h11 * Δt * du_kp1
+    end
+
+    # Test basis functions at key points
+    h00_0, h10_0, h01_0, h11_0 = hermite_basis_functions(0.0)
+    @test h00_0 ≈ 1.0
+    @test h10_0 ≈ 0.0
+    @test h01_0 ≈ 0.0
+    @test h11_0 ≈ 0.0
+
+    h00_1, h10_1, h01_1, h11_1 = hermite_basis_functions(1.0)
+    @test h00_1 ≈ 0.0
+    @test h10_1 ≈ 0.0
+    @test h01_1 ≈ 1.0
+    @test h11_1 ≈ 0.0
+
+    # Test spline evaluation
+    u_k, u_kp1 = 0.0, 1.0
+    du_k, du_kp1 = 0.0, 0.0
+    Δt = 1.0
+
+    @test evaluate_hermite_spline(0.0, u_k, u_kp1, du_k, du_kp1, Δt) ≈ u_k
+    @test evaluate_hermite_spline(1.0, u_k, u_kp1, du_k, du_kp1, Δt) ≈ u_kp1
+    @test evaluate_hermite_spline(0.5, u_k, u_kp1, du_k, du_kp1, Δt) ≈ 0.5
+end
+
+@testitem "Find cubic critical points" begin
+    # Define functions locally for testing
+    function find_cubic_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+        a = 6*u_k + 3*Δt*du_k - 6*u_kp1 + 3*Δt*du_kp1
+        b = -6*u_k - 4*Δt*du_k + 6*u_kp1 - 2*Δt*du_kp1
+        c = Δt * du_k
+
+        critical_points = Float64[]
+
+        if abs(a) < 1e-12
+            if abs(b) > 1e-12
+                τ = -c / b
+                if 0 < τ < 1
+                    push!(critical_points, τ)
+                end
+            end
+        else
+            discriminant = b^2 - 4*a*c
+            if discriminant >= 0
+                sqrt_disc = sqrt(discriminant)
+                τ1 = (-b + sqrt_disc) / (2*a)
+                τ2 = (-b - sqrt_disc) / (2*a)
+                if 0 < τ1 < 1
+                    push!(critical_points, τ1)
+                end
+                if 0 < τ2 < 1
+                    push!(critical_points, τ2)
+                end
+            end
+        end
+
+        return critical_points
+    end
+
+    function hermite_derivative_basis(τ)
+        τ² = τ * τ
+        dh00 = 6τ² - 6τ
+        dh10 = 3τ² - 4τ + 1
+        dh01 = -6τ² + 6τ
+        dh11 = 3τ² - 2τ
+        return (dh00, dh10, dh01, dh11)
+    end
+
+    # Linear spline (no overshoot) - should have no critical points
+    u_k, u_kp1 = 0.0, 1.0
+    du_k, du_kp1 = 1.0, 1.0
+    Δt = 1.0
+
+    τ_crits = find_cubic_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+    @test length(τ_crits) == 0  # Monotonic
+
+    # Spline with overshoot - should have critical point
+    u_k, u_kp1 = 0.0, 1.0
+    du_k, du_kp1 = 3.0, -3.0  # Large opposite slopes → overshoot
+
+    τ_crits = find_cubic_critical_points(u_k, u_kp1, du_k, du_kp1, Δt)
+    @test length(τ_crits) >= 1  # Has at least one critical point
+    @test all(0 .< τ_crits .< 1)  # In valid range
+
+    # Verify critical point is actually an extremum
+    for τ in τ_crits
+        dh00, dh10, dh01, dh11 = hermite_derivative_basis(τ)
+        du_dτ = dh00 * u_k + dh10 * Δt * du_k + dh01 * u_kp1 + dh11 * Δt * du_kp1
+        @test abs(du_dτ) < 1e-10  # Derivative should be ~0 at critical point
+    end
+end
+
+@testitem "CubicSplineExtremaConstraint - basic" begin
+    using NamedTrajectories
+    using LinearAlgebra
+    using Piccolo: CubicSplineExtremaConstraint
+    using Piccolo: NonlinearSegmentConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+
+    N = 10
+    T = 5.0
+    times = collect(range(0, T, length = N))
+
+    # Create trajectory with spline controls
+    traj = NamedTrajectory(
+        (u = 0.5 * randn(2, N), du = 0.1 * randn(2, N), Δt = fill(T/(N-1), N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Apply bound constraints
+    u_min, u_max = -1.0, 1.0
+    constraint = CubicSplineExtremaConstraint(traj, (u_min, u_max))
+
+    @test constraint isa NonlinearSegmentConstraint
+    @test constraint.equality == false  # Inequality
+    @test length(constraint.segments) == N - 1
+
+    # Evaluate constraint
+    values = zeros(constraint.dim)
+    evaluate!(values, constraint, traj)
+
+    # All constraints should be negative (feasible) or zero if trajectory is within bounds
+    # (Initial random trajectory may not satisfy bounds)
+    @test length(values) > 0
+end
+
+@testitem "CubicSplineExtremaConstraint - per drive bounds" begin
+    using NamedTrajectories
+    using Piccolo: CubicSplineExtremaConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+
+    N = 5
+    n_drives = 3
+    traj = NamedTrajectory(
+        (u = randn(n_drives, N), du = randn(n_drives, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Different bounds per drive
+    bounds = [(-1.0, 1.0), (-2.0, 2.0), (-0.5, 0.5)]
+
+    constraint = CubicSplineExtremaConstraint(traj, bounds)
+
+    values = zeros(constraint.dim)
+    evaluate!(values, constraint, traj)
+    @test length(values) > 0
+end
+
+@testitem "CubicSplineSufficientBoundConstraint - basic" begin
+    using NamedTrajectories
+    using Piccolo: CubicSplineSufficientBoundConstraint
+    using Piccolo: NonlinearSegmentConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+
+    N = 10
+    traj = NamedTrajectory(
+        (u = randn(2, N), du = 0.1 * randn(2, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    u_min, u_max = -5.0, 5.0
+    constraint =
+        CubicSplineSufficientBoundConstraint(traj, (u_min, u_max); safety_factor = 2.0)
+
+    @test constraint isa NonlinearSegmentConstraint
+    @test constraint.equality == false
+
+    # Evaluate
+    values = zeros(constraint.dim)
+    evaluate!(values, constraint, traj)
+    @test length(values) == 2 * (N - 1)  # 2 drives × (N-1) segments
+end
+
+@testitem "CubicSplineSufficientBoundConstraint - safety factor effect" begin
+    using NamedTrajectories
+    using Piccolo: CubicSplineSufficientBoundConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+
+    N = 5
+    traj = NamedTrajectory(
+        (u = zeros(1, N), du = ones(1, N), Δt = fill(1.0, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    u_min, u_max = -10.0, 10.0
+
+    # With higher safety factor, constraint should be less restrictive
+    constraint_conservative =
+        CubicSplineSufficientBoundConstraint(traj, (u_min, u_max); safety_factor = 1.0)
+    constraint_moderate =
+        CubicSplineSufficientBoundConstraint(traj, (u_min, u_max); safety_factor = 3.0)
+
+    values_conservative = zeros(constraint_conservative.dim)
+    values_moderate = zeros(constraint_moderate.dim)
+
+    evaluate!(values_conservative, constraint_conservative, traj)
+    evaluate!(values_moderate, constraint_moderate, traj)
+
+    # Higher safety factor → larger allowed slopes → SMALLER residuals under the
+    # backend convention (feasible ⟺ residual = |du| − max_slope ≤ 0): a larger
+    # max_slope subtracts more. (Expectation flipped with the 1eb1b84 sign fix.)
+    @test all(values_moderate .<= values_conservative .+ 1e-10)
+end
+
+@testitem "Spline constraints - integration test" begin
+    using NamedTrajectories
+    using LinearAlgebra
+    using SparseArrays
+    using Piccolo: CubicSplineExtremaConstraint, CubicSplineSufficientBoundConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+    using DirectTrajOpt.Constraints: jacobian!, get_full_jacobian
+
+    # Create a trajectory that violates bounds
+    N = 8
+    traj = NamedTrajectory(
+        (u = 5.0 * randn(1, N), du = 10.0 * randn(1, N), Δt = fill(0.5, N));
+        timestep = :Δt,
+        controls = :u,
+        bounds = (u = (-3.0, 3.0), du = (-5.0, 5.0)),
+    )
+
+    # Apply extrema constraint
+    extrema_con = CubicSplineExtremaConstraint(traj, (-3.0, 3.0))
+
+    # Apply sufficient condition constraint
+    sufficient_con =
+        CubicSplineSufficientBoundConstraint(traj, (-3.0, 3.0); safety_factor = 2.0)
+
+    # Evaluate both
+    vals_extrema = zeros(extrema_con.dim)
+    vals_sufficient = zeros(sufficient_con.dim)
+
+    evaluate!(vals_extrema, extrema_con, traj)
+    evaluate!(vals_sufficient, sufficient_con, traj)
+
+    # Both should produce valid constraint vectors
+    @test length(vals_extrema) > 0
+    @test length(vals_sufficient) > 0
+    @test all(isfinite.(vals_extrema))
+    @test all(isfinite.(vals_sufficient))
+
+    # Jacobian should be computable
+    jacobian!(extrema_con, traj)
+    jacobian!(sufficient_con, traj)
+
+    ∂g_extrema = get_full_jacobian(extrema_con, traj)
+    ∂g_sufficient = get_full_jacobian(sufficient_con, traj)
+
+    @test nnz(∂g_extrema) > 0
+    @test nnz(∂g_sufficient) > 0
+    @test all(isfinite.(∂g_extrema.nzval))
+    @test all(isfinite.(∂g_sufficient.nzval))
+end
+
+@testitem "Slope constraint - basic functionality" begin
+    using NamedTrajectories
+    using Piccolo: CubicSplineSlopeConstraint
+    using DirectTrajOpt.CommonInterface: evaluate!
+
+    # Create trajectory with large derivatives
+    N = 6
+    traj = NamedTrajectory(
+        (u = randn(1, N), du = 10.0 * randn(1, N), Δt = fill(0.5, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # Create slope constraint
+    du_bounds = (-5.0, 5.0)
+    slope_con = CubicSplineSlopeConstraint(traj, du_bounds)
+
+    # Evaluate constraints
+    g = zeros(slope_con.dim)
+    evaluate!(g, slope_con, traj)
+
+    # Should return 3 eval points × 2 bounds × 1 drive × (N-1) segments
+    @test length(g) == 3 * 2 * 1 * (N-1)
+    @test all(isfinite.(g))
+end

--- a/src/control/constraints_spline/stencil_table.jl
+++ b/src/control/constraints_spline/stencil_table.jl
@@ -1,0 +1,1011 @@
+# ============================================================================= #
+#   ConstraintStencilTable — the functional-indexed intermediate representation   #
+# ============================================================================= #
+#
+# ADR-0010 decision 4. The table's ROWS ARE FUNCTIONALS, not constraint rows: each
+# unique scalar quantity the constraint forms is one table row, its CONSTANT columns
+# are stored separately from its PER-ITERATE coefficients, and a SIGNED row-to-
+# functional map says which constraint rows read which functional with which sign.
+#
+# Why not store constraint rows: every double-sided inequality emits a `±` row pair
+# sharing one underlying scalar, so one directional-derivative evaluation serves two
+# rows. A per-row table (or a sparse matrix) stores both rows' stencils
+# independently and forfeits exactly that pairing — which is the entire reason the
+# matrix-free kernels (#332) beat the SpMV. See CONTEXT.md, "Paired constraint rows".
+#
+# The split of labour: THE CONSTRAINT OWNS ITS MATH, THE TABLE OWNS ITS APPLICATION.
+# A constraint implements exactly three things —
+#
+#   (a) a one-time STRUCTURE DECLARATION: which columns each functional touches,
+#       the signed row-to-functional map, the per-row constant, and the stencil
+#       width. That is this constructor's argument list.
+#   (b) a per-iterate COEFFICIENT REFRESH: overwrite `table.coeffs` in place.
+#   (c) a RESIDUAL.
+#
+# Application — sparse fill, sparsity construction, and (in #332) JVP/VJP — is
+# generic over the table and lives here.
+#
+# ALLOCATION. Zero allocation is not the target and is not attainable: the
+# `CommonInterface` hands a constraint a `NamedTrajectory` whose `datavec` is an
+# abstractly-typed field, so one dynamic access costs a constant floor of ~80 B that
+# no kernel work removes, and the backend's own per-callback trajectory wrapper costs
+# ~3.3 kB — roughly forty times a whole optimised constraint kernel. The criterion is
+# KNOT-FLATNESS: per-call allocation must not grow with the knot count. See ADR-0009
+# decision 3 and ADR-0010 decision 6.
+
+"""
+    ConstraintStencilTable
+
+Functional-indexed stencil table for an algebraic constraint's Jacobian.
+
+Each **functional** is one unique scalar quantity the constraint forms (e.g. the
+acceleration at one knot for one drive). Constraint **rows** are then signed,
+offset copies of functionals: `g[r] = row_sign[r] * F[row_functional[r]] +
+row_offset[r]`.
+
+# Fields (declared)
+- `n_functionals`, `n_rows`: table and constraint dimensions.
+- `n_cols`: the FULL decision-vector width, `traj.dim * traj.N + traj.global_dim`.
+  Carried as data, never recomputed at a use site — two constraints previously sized
+  their Jacobians without the global columns, which made the backend's row-stacking
+  throw on any trajectory carrying free phases.
+- `stencil_width`: the maximum number of knots either side of its anchor that one row
+  reads. A *declared* property; the constraint never exchanges halos itself (the
+  sharded driver takes `max` over dynamics and every routed constraint and exchanges
+  once, ADR-0010 decision 7).
+- `col_ptr`, `cols`: constant per-functional column lists, flat/CSR (functional `f`
+  owns `cols[col_ptr[f]:col_ptr[f+1]-1]`).
+- `coeffs`: per-iterate partials, parallel to `cols`. **Mutable** — this is what a
+  coefficient refresh writes.
+- `row_map`: signed row-to-functional map; `sign` is the row's sign, `abs` its
+  functional index.
+- `row_offset`: per-row constant.
+
+# Derived
+`row_sign`, `row_functional`, `functional_row_ptr` (contiguity makes this
+well-defined), the flat assembled-Jacobian entry tables, and the cached
+`SparseMatrixCSC` the assembled entry point returns.
+
+# Invariant
+A functional's constraint rows are **contiguous**, enforced at construction. This is
+what lets the residual write a functional's rows the moment its value is formed,
+with no per-functional buffer and hence no eltype restriction (ForwardDiff works),
+and it is what `#332`'s pair contraction will index by.
+"""
+struct ConstraintStencilTable
+    # ── declared ─────────────────────────────────────────────────────────────── #
+    n_functionals::Int
+    n_rows::Int
+    n_cols::Int
+    stencil_width::Int
+    col_ptr::Vector{Int}
+    cols::Vector{Int}
+    coeffs::Vector{Float64}
+    row_map::Vector{Int}
+    row_offset::Vector{Float64}
+    # ── derived: row view ────────────────────────────────────────────────────── #
+    row_sign::Vector{Float64}
+    row_functional::Vector{Int}
+    functional_row_ptr::Vector{Int}
+    # ── derived: assembled-Jacobian entry tables (structure order) ───────────── #
+    entry_row::Vector{Int}
+    entry_col::Vector{Int}
+    entry_coeff::Vector{Int}     # index into `coeffs`
+    entry_sign::Vector{Float64}
+    J::SparseMatrixCSC{Float64,Int}
+    entry_nzpos::Vector{Int}     # entry k → index into `J.nzval`
+    # ── derived: coefficient-generation counter ──────────────────────────────── #
+    # Bumped by EVERY coefficient refresh (`stencil_touch!`, called from each
+    # constraint's refresh barrier). #332's routed products cache "the coefficients
+    # already match this iterate" on the committed-iterate stamp; but `coeffs` lives on
+    # the CONSTRAINT, not on the caching closure, so a second consumer of the same
+    # constraint — another callback set, or a plain `eval_jacobian` from the
+    # factorisation evaluator — can rewrite it at a different iterate between two
+    # products. The stamp alone would then serve a coefficient set belonging to some
+    # other `x`: exactly #329's staleness defect one level down. A cached read is valid
+    # only when the stamp matches AND this counter is the one the refresh recorded.
+    refresh_token::Base.RefValue{Int}
+end
+
+function ConstraintStencilTable(
+    functional_cols::AbstractVector,
+    row_map::AbstractVector{Int},
+    row_offset::AbstractVector{<:Real},
+    n_cols::Int;
+    stencil_width::Int,
+)
+    n_functionals = length(functional_cols)
+    n_rows = length(row_map)
+
+    n_functionals > 0 || throw(ArgumentError("stencil table declares no functionals"))
+    n_rows > 0 || throw(ArgumentError("stencil table declares no constraint rows"))
+    length(row_offset) == n_rows || throw(
+        ArgumentError(
+            "row_offset has length $(length(row_offset)), expected $n_rows (one per row)",
+        ),
+    )
+    stencil_width >= 0 ||
+        throw(ArgumentError("stencil_width must be non-negative, got $stencil_width"))
+    n_cols > 0 || throw(ArgumentError("n_cols must be positive, got $n_cols"))
+
+    # ── flatten the declared columns ─────────────────────────────────────────── #
+    col_ptr = Vector{Int}(undef, n_functionals + 1)
+    col_ptr[1] = 1
+    for f = 1:n_functionals
+        nc = length(functional_cols[f])
+        nc > 0 || throw(ArgumentError("functional $f declares no columns"))
+        col_ptr[f+1] = col_ptr[f] + nc
+    end
+    cols = Vector{Int}(undef, col_ptr[end] - 1)
+    for f = 1:n_functionals
+        for (j, c) in enumerate(functional_cols[f])
+            1 <= c <= n_cols || throw(
+                ArgumentError(
+                    "functional $f column $c out of range 1:$n_cols — the column count " *
+                    "must include the global variables",
+                ),
+            )
+            cols[col_ptr[f]+j-1] = c
+        end
+    end
+    coeffs = zeros(Float64, length(cols))
+
+    # ── row view + the contiguity invariant ──────────────────────────────────── #
+    row_sign = Vector{Float64}(undef, n_rows)
+    row_functional = Vector{Int}(undef, n_rows)
+    row_count = zeros(Int, n_functionals)
+    first_row = zeros(Int, n_functionals)
+    last_row = zeros(Int, n_functionals)
+    for r = 1:n_rows
+        m = row_map[r]
+        m != 0 || throw(ArgumentError("row $r has a zero (unsigned) functional map entry"))
+        f = abs(m)
+        f <= n_functionals || throw(
+            ArgumentError(
+                "row $r maps to functional $f but only $n_functionals are declared",
+            ),
+        )
+        row_functional[r] = f
+        row_sign[r] = m > 0 ? 1.0 : -1.0
+        row_count[f] += 1
+        first_row[f] == 0 && (first_row[f] = r)
+        last_row[f] = r
+    end
+    for f = 1:n_functionals
+        row_count[f] > 0 || throw(
+            ArgumentError(
+                "functional $f is declared but no constraint row reads it — the table " *
+                "must enumerate functionals from actual rows",
+            ),
+        )
+        last_row[f] - first_row[f] + 1 == row_count[f] || throw(
+            ArgumentError(
+                "functional $f's constraint rows are not contiguous: $(row_count[f]) " *
+                "rows spread over $(first_row[f]):$(last_row[f])",
+            ),
+        )
+    end
+    functional_row_ptr = Vector{Int}(undef, n_functionals + 1)
+    for f = 1:n_functionals
+        functional_row_ptr[f] = first_row[f]
+    end
+    functional_row_ptr[n_functionals+1] = last_row[n_functionals] + 1
+
+    # ── assembled-Jacobian entry tables, in fill (structure) order ───────────── #
+    n_entries = 0
+    for r = 1:n_rows
+        f = row_functional[r]
+        n_entries += col_ptr[f+1] - col_ptr[f]
+    end
+    entry_row = Vector{Int}(undef, n_entries)
+    entry_col = Vector{Int}(undef, n_entries)
+    entry_coeff = Vector{Int}(undef, n_entries)
+    entry_sign = Vector{Float64}(undef, n_entries)
+    e = 0
+    for r = 1:n_rows
+        f = row_functional[r]
+        s = row_sign[r]
+        for j = col_ptr[f]:(col_ptr[f+1]-1)
+            e += 1
+            entry_row[e] = r
+            entry_col[e] = cols[j]
+            entry_coeff[e] = j
+            entry_sign[e] = s
+        end
+    end
+
+    # Cached assembled Jacobian. The pattern never moves, so this is built ONCE and
+    # refilled through `entry_nzpos`; rebuilding a sparse matrix per call was ~6.9 MB
+    # of the measured 6.88 MB per Jacobian at N=801.
+    J = sparse(entry_row, entry_col, ones(Float64, n_entries), n_rows, n_cols)
+    entry_nzpos = Vector{Int}(undef, n_entries)
+    for e = 1:n_entries
+        r, c = entry_row[e], entry_col[e]
+        pos = 0
+        @inbounds for k = J.colptr[c]:(J.colptr[c+1]-1)
+            if J.rowval[k] == r
+                pos = k
+                break
+            end
+        end
+        pos == 0 && error("internal: entry ($r, $c) missing from the assembled pattern")
+        entry_nzpos[e] = pos
+    end
+
+    return ConstraintStencilTable(
+        n_functionals,
+        n_rows,
+        n_cols,
+        stencil_width,
+        col_ptr,
+        cols,
+        coeffs,
+        collect(Int, row_map),
+        collect(Float64, row_offset),
+        row_sign,
+        row_functional,
+        functional_row_ptr,
+        entry_row,
+        entry_col,
+        entry_coeff,
+        entry_sign,
+        J,
+        entry_nzpos,
+        Ref(0),
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# Accessors
+# ----------------------------------------------------------------------------- #
+
+"""
+    stencil_n_entries(table) -> Int
+
+Number of assembled-Jacobian nonzero entries (rows × their functional's columns).
+"""
+stencil_n_entries(t::ConstraintStencilTable) = length(t.entry_row)
+
+"""
+    stencil_coeff_range(table, f) -> UnitRange{Int}
+
+Indices into `table.cols` / `table.coeffs` owned by functional `f`. This is what a
+coefficient refresh writes into.
+"""
+@inline stencil_coeff_range(t::ConstraintStencilTable, f::Int) =
+    t.col_ptr[f]:(t.col_ptr[f+1]-1)
+
+"""
+    stencil_functional_rows(table, f) -> UnitRange{Int}
+
+The contiguous constraint rows that read functional `f`.
+"""
+@inline stencil_functional_rows(t::ConstraintStencilTable, f::Int) =
+    t.functional_row_ptr[f]:(t.functional_row_ptr[f+1]-1)
+
+"""
+    stencil_refresh_token(table) -> Int
+
+The table's coefficient generation: a monotone counter bumped by every coefficient
+refresh. A consumer that caches "the coefficients already match iterate `x`" must record
+this alongside its iterate stamp and re-check both, because `coeffs` belongs to the
+constraint and any other consumer may rewrite it in between. See the field's comment.
+"""
+@inline stencil_refresh_token(t::ConstraintStencilTable) = t.refresh_token[]
+
+"""
+    stencil_touch!(table)
+
+Record that `table.coeffs` has just been rewritten. Called at the end of every
+constraint's coefficient-refresh barrier; allocation-free.
+"""
+@inline function stencil_touch!(t::ConstraintStencilTable)
+    t.refresh_token[] += 1
+    return nothing
+end
+
+# ----------------------------------------------------------------------------- #
+# Generic application
+# ----------------------------------------------------------------------------- #
+
+"""
+    stencil_structure(table) -> Vector{Tuple{Int,Int}}
+
+The assembled Jacobian's `(row, column)` sparsity structure, in the same order
+[`stencil_fill_values!`](@ref) writes. Built once; this is what a constraint returns
+from `jacobian_structure`.
+"""
+function stencil_structure(t::ConstraintStencilTable)
+    return [(t.entry_row[e], t.entry_col[e]) for e = 1:stencil_n_entries(t)]
+end
+
+"""
+    stencil_fill_values!(vals, table)
+
+Write the assembled Jacobian's nonzero values into `vals`, in
+[`stencil_structure`](@ref) order: `vals[e] = row_sign * coeff`. Allocation-free.
+"""
+function stencil_fill_values!(vals::AbstractVector, t::ConstraintStencilTable)
+    n = stencil_n_entries(t)
+    length(vals) >= n ||
+        throw(DimensionMismatch("value buffer has length $(length(vals)), need $n"))
+    coeffs = t.coeffs
+    sgn = t.entry_sign
+    src = t.entry_coeff
+    @inbounds for e = 1:n
+        vals[e] = sgn[e] * coeffs[src[e]]
+    end
+    return vals
+end
+
+"""
+    stencil_assemble!(table) -> SparseMatrixCSC
+
+Refresh and return the CACHED assembled Jacobian. The pattern is built once at
+construction, so this only overwrites `nzval` — the returned matrix is the same
+object on every call (the pre-allocated-reference convention already used by
+`CubicSplineBoundConstraint` and DirectTrajOpt's `KnotPointConstraint`).
+"""
+function stencil_assemble!(t::ConstraintStencilTable)
+    J = t.J
+    nz = J.nzval
+    coeffs = t.coeffs
+    sgn = t.entry_sign
+    src = t.entry_coeff
+    pos = t.entry_nzpos
+    @inbounds for e in eachindex(pos)
+        nz[pos[e]] = sgn[e] * coeffs[src[e]]
+    end
+    return J
+end
+
+"""
+    stencil_scatter_functional!(g, table, f, val)
+
+Write functional `f`'s value into every constraint row that reads it:
+`g[r] = row_sign[r] * val + row_offset[r]`.
+
+Generic in `eltype(g)` and in `typeof(val)` (ForwardDiff duals included) and
+allocation-free, because the invariant that `f`'s rows are contiguous means no
+per-functional buffer is needed — the value is consumed the moment it is formed.
+"""
+@inline function stencil_scatter_functional!(
+    g::AbstractVector,
+    t::ConstraintStencilTable,
+    f::Int,
+    val,
+)
+    sgn = t.row_sign
+    off = t.row_offset
+    @inbounds for r = t.functional_row_ptr[f]:(t.functional_row_ptr[f+1]-1)
+        g[r] = sgn[r] * val + off[r]
+    end
+    return nothing
+end
+
+"""
+    stencil_expand_rows!(g, table, fvals)
+
+Expand a full vector of functional values into constraint rows. Convenience wrapper
+over [`stencil_scatter_functional!`](@ref); the hot residual path scatters as it goes
+instead.
+"""
+function stencil_expand_rows!(
+    g::AbstractVector,
+    t::ConstraintStencilTable,
+    fvals::AbstractVector,
+)
+    length(fvals) == t.n_functionals || throw(
+        DimensionMismatch("fvals has length $(length(fvals)), expected $(t.n_functionals)"),
+    )
+    for f = 1:t.n_functionals
+        stencil_scatter_functional!(g, t, f, fvals[f])
+    end
+    return g
+end
+
+# ----------------------------------------------------------------------------- #
+# Matrix-free application (#332)
+# ----------------------------------------------------------------------------- #
+#
+# THE REASON THESE EXIST. The assembled Jacobian is cheap to refill, so the naive
+# reading is "cache it and pay a SpMV". That is wrong for a structural reason: a
+# double-sided inequality's `±` row pair shares ONE underlying scalar, so one
+# directional-derivative evaluation serves both rows. A sparse matrix stores the two
+# rows' stencils independently and re-does the contraction per row; these kernels
+# contract ONCE PER FUNCTIONAL instead.
+#
+#   JVP: contract the functional's stencil against `v` once  →  write both rows.
+#   VJP: contract the pair's WEIGHTS first (`ω = Σ_r sign_r · w_r`)  →  scatter once.
+#
+# Combine coefficients, apply once — the constraint-side analogue of the MultiKet
+# parameter-block reassociation. An implementation that scatters per row forfeits the
+# entire win (ADR-0010 decision 3, CONTEXT.md "Paired constraint rows").
+#
+# Both are range reductions rather than gathers because a functional's rows are
+# CONTIGUOUS, an invariant this table enforces at construction.
+
+"""
+    stencil_jvp!(Jv, table, v) -> Jv
+
+Matrix-free Jacobian-vector product: `Jv[r] = row_sign[r] · (∂F_f/∂z ⋅ v)` for every
+constraint row `r` reading functional `f`.
+
+One contraction per FUNCTIONAL, then every row of its `±` pair is written from that one
+scalar — this is where the win over the equivalent SpMV comes from.
+
+`Jv` is **overwritten** over `1:table.n_rows` (a routed block owns a disjoint row range,
+so no accumulation is needed and none is done). `v` is the FULL decision vector, so
+`length(v)` must be `table.n_cols`. `row_offset` plays no part: it is the residual's
+constant and has no derivative.
+
+Allocation-free.
+"""
+function stencil_jvp!(
+    Jv::AbstractVector{Float64},
+    t::ConstraintStencilTable,
+    v::AbstractVector{Float64},
+)
+    length(Jv) == t.n_rows ||
+        throw(DimensionMismatch("Jv has length $(length(Jv)), expected $(t.n_rows) rows"))
+    length(v) == t.n_cols || throw(
+        DimensionMismatch(
+            "v has length $(length(v)), expected the full decision width $(t.n_cols)",
+        ),
+    )
+    cols = t.cols
+    coeffs = t.coeffs
+    col_ptr = t.col_ptr
+    sgn = t.row_sign
+    rp = t.functional_row_ptr
+    @inbounds for f = 1:t.n_functionals
+        # TWO accumulators, not one. A stencil is five to eight columns long, so the
+        # single-accumulator form is a serial chain of that many dependent FMAs with
+        # nothing to overlap them — measured, splitting it is worth ~1.2-1.3× on the whole
+        # kernel (33.3 → 27.8 µs at N=801 for the continuity constraint). Anything wider
+        # stops paying: at this stencil length the gather, not the chain, becomes the
+        # limit. The pairwise order is why parity with the assembled matvec is asserted at
+        # `rtol`, not bitwise — both are correct summations of the same terms.
+        lo = col_ptr[f]
+        hi = col_ptr[f+1] - 1
+        d1 = 0.0
+        d2 = 0.0
+        j = lo
+        while j + 1 <= hi
+            d1 += coeffs[j] * v[cols[j]]
+            d2 += coeffs[j+1] * v[cols[j+1]]
+            j += 2
+        end
+        j <= hi && (d1 += coeffs[j] * v[cols[j]])
+        d = d1 + d2
+        for r = rp[f]:(rp[f+1]-1)
+            Jv[r] = sgn[r] * d
+        end
+    end
+    return Jv
+end
+
+"""
+    stencil_vjp!(JTw, table, w) -> JTw
+
+Matrix-free transpose product: `JTw += Jᵀw`.
+
+The pair's weights are contracted FIRST — `ω_f = Σ_{r reads f} row_sign[r] · w[r]`, a
+reduction over a contiguous range — and only then is the functional's stencil scattered,
+once. Scattering per row instead would touch every partial twice and forfeit the win.
+
+**ACCUMULATES** into `JTw` (unlike [`stencil_jvp!`](@ref), which overwrites): several
+routed constraints share one `n_cols`-wide output, and so does the dense remainder. The
+caller zeroes. `length(JTw)` must be `table.n_cols`, `length(w)` must be `table.n_rows`
+(pass a `view` of the block's rows).
+
+Allocation-free.
+"""
+function stencil_vjp!(
+    JTw::AbstractVector{Float64},
+    t::ConstraintStencilTable,
+    w::AbstractVector{Float64},
+)
+    length(JTw) == t.n_cols || throw(
+        DimensionMismatch(
+            "JTw has length $(length(JTw)), expected the full decision width $(t.n_cols)",
+        ),
+    )
+    length(w) == t.n_rows ||
+        throw(DimensionMismatch("w has length $(length(w)), expected $(t.n_rows) rows"))
+    cols = t.cols
+    coeffs = t.coeffs
+    col_ptr = t.col_ptr
+    sgn = t.row_sign
+    rp = t.functional_row_ptr
+    @inbounds for f = 1:t.n_functionals
+        ω = 0.0
+        for r = rp[f]:(rp[f+1]-1)
+            ω += sgn[r] * w[r]
+        end
+        for j = col_ptr[f]:(col_ptr[f+1]-1)
+            JTw[cols[j]] += ω * coeffs[j]
+        end
+    end
+    return JTw
+end
+
+# ----------------------------------------------------------------------------- #
+# The constraint-type gradient trait (#332)
+# ----------------------------------------------------------------------------- #
+#
+# ADR-0010 decisions 1 and 2: the gradient method for an algebraic constraint is
+# dispatched on the CONSTRAINT TYPE (constraints have no integration algorithm, so
+# ADR-0003's algorithm-dispatch rule does not reach them), and the vocabulary stays
+# INSIDE the package that owns the constraint types (Piccolo since the open-core
+# split's 3c slice — re-exported by Piccolissimo —, so an upstream split buys no
+# consumer). This is the inequality-path sibling of the backend's
+# `_supports_matrix_free_eq_gradient`.
+#
+# HOW A CONSTRAINT OPTS IN — exactly two methods:
+#
+#   constraint_stencil_table(c::MyConstraint) = c.table
+#   refresh_constraint_coefficients!(c::MyConstraint, traj) =
+#       _my_refresh_coefficients!(traj.datavec, c.tag, c.table)
+#
+# `supports_matrix_free_constraint_gradient` is then DERIVED and must not be overridden:
+# routability is a property of the declared table, not an independent opt-in flag, so a
+# constraint cannot claim to be routable without supplying a table whose stencil width is
+# bounded. That is what "refused at the trait, not silently routed" means.
+#
+# #333 (device kernels) and #334 (the sharded path) extend this same trait rather than
+# adding a parallel one: they consume `constraint_stencil_table` (the declared structure
+# they upload / slab-index) and `refresh_constraint_coefficients!` (the per-iterate
+# cadence), and gate on the same predicate.
+
+"""
+    UNBOUNDED_STENCIL_WIDTH
+
+The stencil width a constraint declares when its rows are **not** knot-local — a
+periodicity row coupling knot 1 with knot `N`, or a global `∫u dt` budget coupling all of
+them. Such a constraint is refused by
+[`supports_matrix_free_constraint_gradient`](@ref) and stays on the assembled path: its
+rows are not owned by one rank, so it needs non-adjacent point-to-point or a reduction
+rather than the single bounded halo the driver exchanges (ADR-0010 decision 7).
+"""
+const UNBOUNDED_STENCIL_WIDTH = typemax(Int)
+
+"""
+    constraint_stencil_table(constraint) -> Union{Nothing,ConstraintStencilTable}
+
+The constraint's declared stencil table, or `nothing` (the default) for a constraint that
+has none — the three ForwardDiff-backed types, which stay on the assembled path.
+
+One half of the gradient trait; see this section's comment for the two-method opt-in.
+"""
+constraint_stencil_table(::Any) = nothing
+
+"""
+    refresh_constraint_coefficients!(constraint, traj)
+
+Overwrite the constraint's stencil coefficients from `traj` for the current iterate, and
+[`stencil_touch!`](@ref) the table. The other half of the gradient trait.
+
+Called on the **once-per-accepted-iterate** cadence, never per product: keeping the
+constant columns separate from the per-iterate coefficients is exactly what buys that
+cadence (ADR-0010 decision 4), and re-refreshing per product would cost more than the
+SpMV the kernels are replacing.
+"""
+function refresh_constraint_coefficients!(c, ::Any)
+    throw(
+        ArgumentError(
+            "$(typeof(c)) declares a stencil table but no `refresh_constraint_coefficients!` " *
+            "method — a routable constraint must supply BOTH halves of the gradient trait",
+        ),
+    )
+end
+
+"""
+    supports_matrix_free_constraint_gradient(constraint) -> Bool
+
+Whether the backend should serve this constraint's inequality rows from the matrix-free
+[`stencil_jvp!`](@ref) / [`stencil_vjp!`](@ref) kernels instead of from a block of the
+assembled inequality Jacobian.
+
+DERIVED, never overridden: `true` exactly when the constraint declares a stencil table
+whose stencil width is bounded. A constraint whose rows are not knot-local declares
+[`UNBOUNDED_STENCIL_WIDTH`](@ref) and is refused here — at the trait, rather than being
+silently routed into a kernel whose halo assumption it violates.
+"""
+supports_matrix_free_constraint_gradient(c) = _routable_stencil(constraint_stencil_table(c))
+
+_routable_stencil(::Nothing) = false
+_routable_stencil(t::ConstraintStencilTable) =
+    0 <= t.stencil_width < UNBOUNDED_STENCIL_WIDTH
+
+# The HVP sibling of that trait (#458) lives right below, with the kernels it names.
+
+@testitem "ConstraintStencilTable: structure, ± pairing, cached assembly" begin
+
+    ConstraintStencilTable,
+    stencil_structure,
+    stencil_fill_values!,
+    stencil_assemble!,
+    stencil_expand_rows!,
+    stencil_coeff_range,
+    stencil_functional_rows,
+    stencil_n_entries
+    using SparseArrays
+
+    # Two functionals; each read by a `+`/`−` row pair — the double-sided shape.
+    fcols = [[1, 2, 5], [2, 3]]
+    row_map = [1, -1, 2, -2]
+    row_offset = [-10.0, -10.0, 0.0, 0.0]
+    t = ConstraintStencilTable(fcols, row_map, row_offset, 7; stencil_width = 2)
+
+    @test t.n_functionals == 2
+    @test t.n_rows == 4
+    @test t.n_cols == 7            # includes the global columns, carried as data
+    @test t.stencil_width == 2
+    @test stencil_n_entries(t) == 3 + 3 + 2 + 2
+    @test collect(stencil_coeff_range(t, 1)) == [1, 2, 3]
+    @test collect(stencil_coeff_range(t, 2)) == [4, 5]
+    @test stencil_functional_rows(t, 1) == 1:2
+    @test stencil_functional_rows(t, 2) == 3:4
+
+    # Structure is row-major, each row carrying its functional's columns in order.
+    @test stencil_structure(t) ==
+          [(1, 1), (1, 2), (1, 5), (2, 1), (2, 2), (2, 5), (3, 2), (3, 3), (4, 2), (4, 3)]
+
+    # A coefficient refresh writes `coeffs`; application is generic over it.
+    t.coeffs .= [1.0, 2.0, 3.0, 4.0, 5.0]
+    vals = zeros(stencil_n_entries(t))
+    stencil_fill_values!(vals, t)
+    @test vals == [1.0, 2.0, 3.0, -1.0, -2.0, -3.0, 4.0, 5.0, -4.0, -5.0]
+
+    J = stencil_assemble!(t)
+    @test size(J) == (4, 7)
+    @test J[1, 1] == 1.0 && J[1, 2] == 2.0 && J[1, 5] == 3.0
+    @test J[2, 1] == -1.0 && J[2, 2] == -2.0 && J[2, 5] == -3.0
+    @test J[3, 2] == 4.0 && J[3, 3] == 5.0
+    @test J[4, 2] == -4.0 && J[4, 3] == -5.0
+
+    # The assembled matrix is a CACHED reference refilled in place — no per-call
+    # sparse rebuild. Same object, new values.
+    J_first = J
+    t.coeffs .*= 2
+    J_second = stencil_assemble!(t)
+    @test J_second === J_first
+    @test J_second[1, 1] == 2.0
+
+    # Row expansion applies the signed map and the per-row constant.
+    g = zeros(4)
+    stencil_expand_rows!(g, t, [7.0, -1.5])
+    @test g == [7.0 - 10.0, -7.0 - 10.0, -1.5, 1.5]
+
+    # Allocation-free application (both are pure index arithmetic).
+    fv = [7.0, -1.5]
+    fill_alloc = () -> stencil_fill_values!(vals, t)
+    asm_alloc = () -> stencil_assemble!(t)
+    exp_alloc = () -> stencil_expand_rows!(g, t, fv)
+    for f in (fill_alloc, asm_alloc, exp_alloc)
+        f()
+        f()
+        @test minimum(@allocated(f()) for _ = 1:3) == 0
+    end
+end
+
+@testitem "ConstraintStencilTable: the contiguity invariant is enforced at construction" begin
+    using Piccolo: ConstraintStencilTable
+
+    fcols = [[1, 2], [2, 3]]
+
+    # Deliberately MIS-ORDERED: functional 1's two rows are split by functional 2's.
+    # Assuming contiguity instead of enforcing it would silently corrupt every
+    # functional-indexed application (the residual writes a functional's rows as one
+    # contiguous span).
+    @test_throws ArgumentError ConstraintStencilTable(
+        fcols,
+        [1, 2, -1, -2],
+        zeros(4),
+        6;
+        stencil_width = 1,
+    )
+
+    # The correctly-grouped version of the same declaration constructs.
+    t = ConstraintStencilTable(fcols, [1, -1, 2, -2], zeros(4), 6; stencil_width = 1)
+    @test t.n_rows == 4
+
+    # …and the other declaration errors, each on its own message.
+    @test_throws ArgumentError ConstraintStencilTable(
+        fcols,
+        [1, -1, 0, -2],           # zero map entry: no sign
+        zeros(4),
+        6;
+        stencil_width = 1,
+    )
+    @test_throws ArgumentError ConstraintStencilTable(
+        fcols,
+        [1, -1, 3, -3],           # functional out of range
+        zeros(4),
+        6;
+        stencil_width = 1,
+    )
+    @test_throws ArgumentError ConstraintStencilTable(
+        fcols,
+        [1, -1],                  # functional 2 declared but unread
+        zeros(2),
+        6;
+        stencil_width = 1,
+    )
+    @test_throws ArgumentError ConstraintStencilTable(
+        fcols,
+        [1, -1, 2, -2],
+        zeros(4),
+        2;                        # a column beyond n_cols — the globals-omitted bug
+        stencil_width = 1,
+    )
+    @test_throws ArgumentError ConstraintStencilTable(
+        fcols,
+        [1, -1, 2, -2],
+        zeros(3),                 # row_offset/row_map length disagreement
+        6;
+        stencil_width = 1,
+    )
+end
+
+@testitem "#332 stencil kernels: JVP/VJP match the assembled action, adjoint identity, ± reassociation" begin
+
+    ConstraintStencilTable,
+    stencil_assemble!,
+    stencil_jvp!,
+    stencil_vjp!,
+    stencil_refresh_token,
+    stencil_touch!
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(0x332001)
+
+    # A `±` pair on functional 1, an ASYMMETRIC row group on functional 2 (three rows,
+    # mixed signs — the shape a per-row kernel would get right by accident and a paired
+    # one must get right on purpose), and a single-row functional 3.
+    fcols = [[1, 2, 7], [2, 3, 4], [5, 6]]
+    row_map = [1, -1, 2, -2, 2, 3]
+    row_offset = [-1.0, -2.0, 0.5, 0.25, -3.0, 4.0]
+    n_cols = 9
+    t = ConstraintStencilTable(fcols, row_map, row_offset, n_cols; stencil_width = 1)
+    t.coeffs .= randn(length(t.coeffs))
+
+    J = Matrix(stencil_assemble!(t))          # the ORACLE: the assembled Jacobian
+    v = randn(n_cols)
+    w = randn(t.n_rows)
+
+    # ── Parity with the assembled action, to machine precision. ──────────────────── #
+    Jv = zeros(t.n_rows)
+    stencil_jvp!(Jv, t, v)
+    @test Jv ≈ J * v atol = 1e-14
+
+    JTw = zeros(n_cols)
+    stencil_vjp!(JTw, t, w)
+    @test JTw ≈ J' * w atol = 1e-14
+
+    # ── Adjoint identity ⟨Jv, w⟩ == ⟨v, Jᵀw⟩, kernel against kernel. ─────────────── #
+    @test dot(Jv, w) ≈ dot(v, JTw) atol = 1e-13
+
+    # ── The `±` reassociation, asserted on VALUES rather than on timing: the pair's
+    #    rows must be exact negatives of one another in the JVP (one contraction, two
+    #    signed writes), and a pair carrying EQUAL weights must contribute exactly
+    #    nothing to the VJP because ω = w₊ - w₋ = 0 cancels BEFORE any partial is
+    #    touched. An implementation that scatters per row still gets the first; only one
+    #    that contracts the weights first gets the second exactly.
+    @test Jv[1] == -Jv[2]
+    w_bal = zeros(t.n_rows)
+    w_bal[1] = 0.75
+    w_bal[2] = 0.75
+    JTw_bal = zeros(n_cols)
+    stencil_vjp!(JTw_bal, t, w_bal)
+    @test all(iszero, JTw_bal)
+
+    # ── VJP ACCUMULATES (several routed blocks share one output). ─────────────────── #
+    acc = copy(JTw)
+    stencil_vjp!(acc, t, w)
+    @test acc ≈ 2 .* JTw atol = 1e-13
+    # …and the JVP OVERWRITES.
+    Jv_dirty = fill(1e6, t.n_rows)
+    stencil_jvp!(Jv_dirty, t, v)
+    @test Jv_dirty == Jv
+
+    # ── Allocation-free. Local-scoped closures only. ─────────────────────────────── #
+    jvp_f = () -> stencil_jvp!(Jv, t, v)
+    vjp_f = () -> stencil_vjp!(JTw, t, w)
+    for f in (jvp_f, vjp_f)
+        f()
+        f()
+        @test minimum(@allocated(f()) for _ = 1:3) == 0
+    end
+
+    # ── Dimension contracts are enforced, not silently truncated. ────────────────── #
+    @test_throws DimensionMismatch stencil_jvp!(zeros(t.n_rows), t, zeros(n_cols - 1))
+    @test_throws DimensionMismatch stencil_jvp!(zeros(t.n_rows - 1), t, v)
+    @test_throws DimensionMismatch stencil_vjp!(zeros(n_cols - 1), t, w)
+    @test_throws DimensionMismatch stencil_vjp!(zeros(n_cols), t, zeros(t.n_rows - 1))
+
+    # ── The refresh token is monotone and bumped only by an explicit touch. ──────── #
+    tok = stencil_refresh_token(t)
+    stencil_jvp!(Jv, t, v)
+    @test stencil_refresh_token(t) == tok      # a product never touches the coefficients
+    stencil_touch!(t)
+    @test stencil_refresh_token(t) == tok + 1
+    touch_f = () -> stencil_touch!(t)
+    touch_f()
+    @test minimum(@allocated(touch_f()) for _ = 1:3) == 0
+end
+
+@testitem "#332 gradient trait: derived from the declared table, unbounded width refused" begin
+    using Piccolo
+
+    ConstraintStencilTable,
+    constraint_stencil_table,
+    refresh_constraint_coefficients!,
+    supports_matrix_free_constraint_gradient,
+    UNBOUNDED_STENCIL_WIDTH
+
+    fcols = [[1, 2], [2, 3]]
+    bounded = ConstraintStencilTable(fcols, [1, -1, 2, -2], zeros(4), 5; stencil_width = 1)
+    unbounded = ConstraintStencilTable(
+        fcols,
+        [1, -1, 2, -2],
+        zeros(4),
+        5;
+        stencil_width = UNBOUNDED_STENCIL_WIDTH,
+    )
+
+    # A constraint with no table at all — the three ForwardDiff-backed types' situation.
+    struct _NoTableCon end
+    @test constraint_stencil_table(_NoTableCon()) === nothing
+    @test supports_matrix_free_constraint_gradient(_NoTableCon()) == false
+
+    # Opting in is two methods: the table, and the refresh.
+    struct _BoundedCon
+        table::ConstraintStencilTable
+    end
+    Piccolo.Control.QuantumConstraints.SplineConstraints.constraint_stencil_table(
+        c::_BoundedCon,
+    ) = c.table
+    @test supports_matrix_free_constraint_gradient(_BoundedCon(bounded)) == true
+
+    # A NON-knot-local constraint is refused AT THE TRAIT, not silently routed into a
+    # kernel whose one-knot-halo assumption it violates.
+    @test supports_matrix_free_constraint_gradient(_BoundedCon(unbounded)) == false
+
+    # Declaring a table without a refresh is a loud error, not a wrong answer.
+    @test_throws ArgumentError refresh_constraint_coefficients!(
+        _BoundedCon(bounded),
+        nothing,
+    )
+end
+
+# ----------------------------------------------------------------------------- #
+# The inequality HVP trait (#458)                                               #
+# ----------------------------------------------------------------------------- #
+
+"""
+    supports_matrix_free_constraint_hvp(constraint) -> Bool
+
+Whether this constraint supplies an exact per-functional Hessian action the backend's
+inequality path can compose into `compute_inequality_constraint_hvp!` — the matrix-free
+action `Σ_f ω_f ∇²F_f · v` over the constraint's stencil functionals, with
+`ω_f = Σ_{r reads f} row_sign[r] · w[r]` ([`stencil_functional_weight`](@ref)).
+
+**DECLARED, never derived, never delegated** (ADR-0010 decision 1's vocabulary): there is
+no structural property of a [`ConstraintStencilTable`](@ref) that implies a second-order
+action — the table carries first-order coefficient data only — so unlike
+[`supports_matrix_free_constraint_gradient`](@ref) this trait is an explicit per-family
+opt-in. The default is `false`, and a family opts in by declaring `true` AND supplying a
+[`constraint_stencil_hvp!`](@ref) method (whose default throws — declaring support without
+the action is a loud error, mirroring the `refresh_constraint_coefficients!` pairing).
+Constraints without the trait keep the Gauss-Newton fold (`ρJᵀJ`) as their entire
+inequality curvature; nothing infers a Hessian through AD at the backend.
+"""
+supports_matrix_free_constraint_hvp(::Any) = false
+
+"""
+    stencil_functional_weight(table, w, f) -> Float64
+
+Contract the stacked multiplier weights over functional `f`'s (contiguous) constraint
+rows: `ω_f = Σ_r row_sign[r] · w[r]`. This is the VJP's weight contraction standing alone,
+and it is the ONLY weight information an exact inequality HVP needs: constraint rows are
+signed copies of functionals, `g[r] = row_sign[r] · F[row_functional[r]] + row_offset[r]`,
+so `Σ_r w_r ∇²g_r = Σ_f ω_f ∇²F_f` — the `row_offset` drops out as an affine constant and
+the `±` pair collapses into one scalar weight before any second-order work happens.
+
+`length(w)` must be `table.n_rows` (pass a `view` of the block's rows). Allocation-free.
+"""
+@inline function stencil_functional_weight(
+    t::ConstraintStencilTable,
+    w::AbstractVector{Float64},
+    f::Int,
+)
+    length(w) == t.n_rows ||
+        throw(DimensionMismatch("w has length $(length(w)), expected $(t.n_rows) rows"))
+    ω = 0.0
+    sgn = t.row_sign
+    rp = t.functional_row_ptr
+    @inbounds for r = rp[f]:(rp[f+1]-1)
+        ω += sgn[r] * w[r]
+    end
+    return ω
+end
+
+"""
+    constraint_stencil_hvp!(Hv, constraint, w, v, x)
+
+Add the constraint's exact inequality Hessian-of-Lagrangian action to `Hv`:
+`Hv += Σ_f ω_f ∇²F_f(x) · v` over the constraint's stencil functionals, with the
+multiplier weights `w` over the constraint's OWN rows ([`stencil_functional_weight`](@ref)
+does the contraction) and `v` the full decision vector.
+
+**ACCUMULATES** into `Hv` (unlike the routed JVP, which overwrites): several routed
+constraints share one `n_cols`-wide output, and so does the dense remainder. The callback
+that calls this zeroes first. `length(Hv)` must be the full decision width
+`table.n_cols`.
+
+One method per opting-in family — the constraint owns its second-order math exactly as it
+owns its coefficient refresh. The `::Any` default throws: reaching it means the caller
+gated on [`supports_matrix_free_constraint_hvp`](@ref) but the family never supplied its
+action, which is a wiring bug, not a runtime contingency.
+"""
+function constraint_stencil_hvp!(
+    Hv::AbstractVector{Float64},
+    c::Any,
+    w::AbstractVector{Float64},
+    v::AbstractVector{Float64},
+    x::AbstractVector{Float64},
+)
+    throw(
+        ArgumentError(
+            "$(typeof(c)) declares `supports_matrix_free_constraint_hvp` but supplies no " *
+            "`constraint_stencil_hvp!` method — an opting-in family must supply BOTH " *
+            "halves, exactly like the gradient trait",
+        ),
+    )
+end
+
+@testitem "#458 HVP trait: declared per family, default false; weight contraction" begin
+
+    ConstraintStencilTable, stencil_functional_weight, supports_matrix_free_constraint_hvp
+
+    # The default is false and is stated on Any: a ForwardDiff-backed constraint (or any
+    # type at all) never carries an HVP capability into the backend.
+    struct _NoHVPCon end
+    @test supports_matrix_free_constraint_hvp(_NoHVPCon()) == false
+
+    # The weight contraction is the VJP's, standing alone: signed, over the contiguous
+    # row range, on the FUNCTIONALS — the ± pair collapses into one scalar.
+    fcols = [[1, 2, 7], [2, 3, 4], [5, 6]]
+    row_map = [1, -1, 2, -2, 2, 3]
+    t = ConstraintStencilTable(fcols, row_map, zeros(6), 9; stencil_width = 1)
+    w = [0.25, 0.75, -1.5, 2.0, 0.5, -0.5]
+    # functional 1: rows 1,2 (signs +,−)  →  0.25 − 0.75
+    @test stencil_functional_weight(t, w, 1) == 0.25 - 0.75
+    # functional 2: rows 3,4,5 (signs +,−,+ — the asymmetric group)
+    #   →  −1.5 − 2.0 + 0.5
+    @test stencil_functional_weight(t, w, 2) == -1.5 - 2.0 + 0.5
+    # functional 3: row 6 (sign +)  →  −0.5
+    @test stencil_functional_weight(t, w, 3) == -0.5
+
+    # A balanced ± pair contracts to EXACTLY zero — the whole pairing win, one level up.
+    w_bal = zeros(6)
+    w_bal[1] = 0.75
+    w_bal[2] = 0.75
+    @test stencil_functional_weight(t, w_bal, 1) == 0.0
+
+    # Dimension contract enforced, not silently truncated.
+    @test_throws DimensionMismatch stencil_functional_weight(t, zeros(5), 1)
+
+    # Allocation-free. Local-scoped `let` bindings on purpose: a closure at the
+    # testitem's module scope captures `Any`-typed globals and boxes the scalar
+    # return — the same measurement fault the #332 testitem's comment documents.
+    let wt = t, ww = w
+        wf = () -> stencil_functional_weight(wt, ww, 2)
+        wf()
+        wf()
+        @test minimum(@allocated(wf()) for _ = 1:3) == 0
+    end
+end

--- a/src/control/constraints_spline/stencil_table.jl
+++ b/src/control/constraints_spline/stencil_table.jl
@@ -622,14 +622,15 @@ _routable_stencil(t::ConstraintStencilTable) =
 
 @testitem "ConstraintStencilTable: structure, ± pairing, cached assembly" begin
 
-    ConstraintStencilTable,
-    stencil_structure,
-    stencil_fill_values!,
-    stencil_assemble!,
-    stencil_expand_rows!,
-    stencil_coeff_range,
-    stencil_functional_rows,
-    stencil_n_entries
+    using Piccolo:
+        ConstraintStencilTable,
+        stencil_assemble!,
+        stencil_coeff_range,
+        stencil_expand_rows!,
+        stencil_fill_values!,
+        stencil_functional_rows,
+        stencil_n_entries,
+        stencil_structure
     using SparseArrays
 
     # Two functionals; each read by a `+`/`−` row pair — the double-sided shape.
@@ -751,12 +752,13 @@ end
 
 @testitem "#332 stencil kernels: JVP/VJP match the assembled action, adjoint identity, ± reassociation" begin
 
-    ConstraintStencilTable,
-    stencil_assemble!,
-    stencil_jvp!,
-    stencil_vjp!,
-    stencil_refresh_token,
-    stencil_touch!
+    using Piccolo:
+        ConstraintStencilTable,
+        stencil_assemble!,
+        stencil_jvp!,
+        stencil_refresh_token,
+        stencil_touch!,
+        stencil_vjp!
     using LinearAlgebra
     using Random
 
@@ -840,11 +842,12 @@ end
 @testitem "#332 gradient trait: derived from the declared table, unbounded width refused" begin
     using Piccolo
 
-    ConstraintStencilTable,
-    constraint_stencil_table,
-    refresh_constraint_coefficients!,
-    supports_matrix_free_constraint_gradient,
-    UNBOUNDED_STENCIL_WIDTH
+    using Piccolo:
+        ConstraintStencilTable,
+        UNBOUNDED_STENCIL_WIDTH,
+        constraint_stencil_table,
+        refresh_constraint_coefficients!,
+        supports_matrix_free_constraint_gradient
 
     fcols = [[1, 2], [2, 3]]
     bounded = ConstraintStencilTable(fcols, [1, -1, 2, -2], zeros(4), 5; stencil_width = 1)
@@ -969,7 +972,10 @@ end
 
 @testitem "#458 HVP trait: declared per family, default false; weight contraction" begin
 
-    ConstraintStencilTable, stencil_functional_weight, supports_matrix_free_constraint_hvp
+    using Piccolo:
+        ConstraintStencilTable,
+        stencil_functional_weight,
+        supports_matrix_free_constraint_hvp
 
     # The default is false and is stated on Any: a ForwardDiff-backed constraint (or any
     # type at all) never carries an HVP capability into the backend.

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -458,32 +458,30 @@ function _spline_pulse_problem(
         end
     end
 
-    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
+    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior.
+    # Slice 3c (#431): CubicSplineBoundConstraint lives in Piccolo
+    # (Control.QuantumConstraints.SplineConstraints) — a hard import; the old
+    # isdefined(Piccolissimo, ...) soft-dependency sniff is gone.
     if spline_interior_bound_constraints
         if qtraj.pulse isa CubicSplinePulse
-            if isdefined(Main, :Piccolissimo) &&
-               isdefined(Piccolissimo, :CubicSplineBoundConstraint)
-                for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
-                    if isfinite(lb) && isfinite(ub)
-                        push!(
-                            constraints,
-                            Piccolissimo.CubicSplineBoundConstraint(
-                                traj,
-                                control_sym,
-                                lb,
-                                ub;
-                                n_interior_points = n_interior_bound_points,
-                            ),
-                        )
-                    end
-                end
-                if _show_details(piccolo_options)
-                    println(
-                        "    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)",
+            for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
+                if isfinite(lb) && isfinite(ub)
+                    push!(
+                        constraints,
+                        CubicSplineBoundConstraint(
+                            traj,
+                            control_sym,
+                            lb,
+                            ub;
+                            n_interior_points = n_interior_bound_points,
+                        ),
                     )
                 end
-            else
-                @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
+            end
+            if _show_details(piccolo_options)
+                println(
+                    "    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)",
+                )
             end
         else
             @warn "spline_interior_bound_constraints=true only for CubicSplinePulse (LinearSplinePulse interior is linear, knot bounds suffice)."
@@ -856,32 +854,30 @@ function _spline_pulse_problem(
         end
     end
 
-    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior
+    # Spline interior bounds (H10) — CubicSplinePulse can exceed knot bounds in interior.
+    # Slice 3c (#431): CubicSplineBoundConstraint lives in Piccolo
+    # (Control.QuantumConstraints.SplineConstraints) — a hard import; the old
+    # isdefined(Piccolissimo, ...) soft-dependency sniff is gone.
     if spline_interior_bound_constraints
         if qtraj.pulse isa CubicSplinePulse
-            if isdefined(Main, :Piccolissimo) &&
-               isdefined(Piccolissimo, :CubicSplineBoundConstraint)
-                for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
-                    if isfinite(lb) && isfinite(ub)
-                        push!(
-                            constraints,
-                            Piccolissimo.CubicSplineBoundConstraint(
-                                traj,
-                                control_sym,
-                                lb,
-                                ub;
-                                n_interior_points = n_interior_bound_points,
-                            ),
-                        )
-                    end
-                end
-                if _show_details(piccolo_options)
-                    println(
-                        "    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)",
+            for (drive_idx, (lb, ub)) in enumerate(sys.drive_bounds)
+                if isfinite(lb) && isfinite(ub)
+                    push!(
+                        constraints,
+                        CubicSplineBoundConstraint(
+                            traj,
+                            control_sym,
+                            lb,
+                            ub;
+                            n_interior_points = n_interior_bound_points,
+                        ),
                     )
                 end
-            else
-                @warn "spline_interior_bound_constraints=true requires Piccolissimo.jl for CubicSplineBoundConstraint. Load Piccolissimo (using Piccolissimo) or set spline_interior_bound_constraints=false. Interior violation at cat α=2 was 28% (3.20 vs 2.5)."
+            end
+            if _show_details(piccolo_options)
+                println(
+                    "    added CubicSplineBoundConstraint (n=$(n_interior_bound_points) per segment, H10)",
+                )
             end
         else
             @warn "spline_interior_bound_constraints=true only for CubicSplinePulse (LinearSplinePulse interior is linear, knot bounds suffice)."
@@ -1999,15 +1995,29 @@ end
     cub = CubicSplinePulse(0.1 * randn(1, N), zeros(1, N), times)
     lin1 = LinearSplinePulse(0.1 * randn(1, N), times)
 
-    # spline_interior_bound_constraints without Piccolissimo loaded: warns and
-    # constructs (the Piccolissimo-present side needs the package; this env
-    # covers the fallback side only).
-    @test_logs (:warn, r"requires Piccolissimo") match_mode = :any SplinePulseProblem(
-        UnitaryTrajectory(sys1, cub, U_goal),
+    # spline_interior_bound_constraints binds via Piccolo's own
+    # SplineConstraints submodule (open-core slice 3c, #431): a HARD import,
+    # no private-package sniff. Piccolissimo is not — and cannot be — a
+    # dependency of this package, so this test env IS the
+    # no-private-package proof (AC 2): the constraint must land and no
+    # fallback warning may fire.
+    bounded_sys = QuantumSystem(0.01 * σz, [σx], [(-1.0, 1.0)])
+    qcp_bounded = SplinePulseProblem(
+        UnitaryTrajectory(bounded_sys, cub, U_goal),
         N;
         integrator_type = :pwc,
         spline_interior_bound_constraints = true,
     )
+    @test any(c -> c isa CubicSplineBoundConstraint, qcp_bounded.prob.constraints)
+    # ...and silently (no fallback warning) for the multi-ket method too.
+    mk_cub_bounded = MultiKetTrajectory(bounded_sys, cub, [ψ0, ψ1], [ψ1, ψ0])
+    qcp_bounded_mk = SplinePulseProblem(
+        mk_cub_bounded,
+        N;
+        integrator_type = :pwc,
+        spline_interior_bound_constraints = true,
+    )
+    @test any(c -> c isa CubicSplineBoundConstraint, qcp_bounded_mk.prob.constraints)
 
     # LinearSplinePulse: knot bounds suffice; the kwarg warns and is inert
     @test_logs (:warn, r"only for CubicSplinePulse") match_mode = :any SplinePulseProblem(
@@ -2016,14 +2026,6 @@ end
         spline_interior_bound_constraints = true,
     )
 
-    # multi-ket method: both warnings, cubic via the acknowledged :pwc backend
-    mk_cub = MultiKetTrajectory(sys1, cub, [ψ0, ψ1], [ψ1, ψ0])
-    @test_logs (:warn, r"requires Piccolissimo") match_mode = :any SplinePulseProblem(
-        mk_cub,
-        N;
-        integrator_type = :pwc,
-        spline_interior_bound_constraints = true,
-    )
     mk_lin = MultiKetTrajectory(sys1, lin1, [ψ0, ψ1], [ψ1, ψ0])
     @test_logs (:warn, r"only for CubicSplinePulse") match_mode = :any SplinePulseProblem(
         mk_lin,

--- a/test/test_spline_reexport_seam.jl
+++ b/test/test_spline_reexport_seam.jl
@@ -34,3 +34,48 @@
     # bare after `using Piccolo`.
     @test isdefined(Piccolo, :unitary_rollout_trajectory)
 end
+
+# ============================================================================ #
+# #431 — the SplineConstraints re-export seam must be complete
+#
+# The 3c extraction (Piccolissimo #431) moved the spline-shape constraint
+# family into the `SplineConstraints` submodule; `src/control/constraints.jl`
+# re-exports the family's names at top level. Same regression contract as the
+# SplineIntegrators guard above: EVERY name the submodule exports resolves at
+# (is re-exported through) `Piccolo`, so the seam cannot silently drift — the
+# exact failure mode #326 recorded for the 3b module's second export block.
+# ============================================================================ #
+
+@testitem "SplineConstraints re-export seam is complete (#431)" begin
+    using Piccolo
+    using Test
+
+    sub = Piccolo.Control.QuantumConstraints.SplineConstraints
+    exported_from_submodule = filter(n -> Base.isexported(sub, n), names(sub; all = false))
+    @test !isempty(exported_from_submodule)
+
+    # The CommonInterface-owned methods the submodule imports but does not
+    # export (evaluate!, jacobian!, ...) never enter this list — the submodule
+    # imports them without export, per the seam convention: interface functions
+    # come from CommonInterface, which `using Piccolo` already reaches through
+    # the DirectTrajOpt re-export.
+    interface_owned = filter(n -> !isdefined(sub, n), exported_from_submodule)
+    spline_owned = setdiff(exported_from_submodule, interface_owned)
+
+    missing_at_top =
+        filter(n -> !isdefined(Piccolo, n) || !Base.isexported(Piccolo, n), spline_owned)
+    @test isempty(missing_at_top)
+
+    # The names that started this slice: the template binds interior spline
+    # bounds through the top-level seam (AC 2), and Piccolissimo's re-export
+    # surface reads the same names.
+    for n in (
+        :CubicSplineBoundConstraint,
+        :HermiteSmoothAccelerationConstraint,
+        :NonlinearSegmentConstraint,
+        :OptimizedNonlinearKnotPointConstraint,
+        :ConstraintStencilTable,
+    )
+        @test isdefined(Piccolo, n) && Base.isexported(Piccolo, n)
+    end
+end


### PR DESCRIPTION
Extraction slice 3c (Piccolissimo #431, amendment 9): the spline bound/extrema/slope constraint family, the nonlinear knot/segment constraints, Hermite primitives, and the ADR-0010 stencil table move to Piccolo — killing the last private-package dependency in Piccolo's own templates.

- **Template hard import**: the runtime soft-dependency sniff for the bending regularizer is gone (RED probe: the old template warns + adds zero constraints; GREEN: interior spline bounds work in an env where Piccolissimo is not a dependency).
- **Complete re-export seam** with the #326 drift-guard pattern applied upfront (caught a missing `export SplineConstraints` in run 1).
- **HermiteC2Regularizer stays proprietary** per amendment 9: deprecation warning → `HermiteBendingEnergyRegularizer`; geometry-equivalent testitems migrated; removal arc marked explicitly. Manifest row 26 struck.
- FiniteDiff joins [extras]/[targets] (1.12 strict load path: no transitive deps).
- Honest incident note: the move rewriter dropped 14 wrapped import headers (tuple-parse silently); caught by the moved testitems in the full suite, repaired in aca64e25, original-vs-moved import coverage diffed clean.

Local suites: Piccolo **9101 / 0 fail / 0 err** / 7 pre-existing broken; Piccolissimo **8682 / 0 fail / 0 err** on the branch-pinned state. Julia 1.12-only. Audit trail: session-20260829-piccolo-stack-program.md L17.